### PR TITLE
v1.14.1 patch

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -25,11 +25,14 @@
 
 				vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
 
-				gl_PointSize = size * ( 300.0 / -mvPosition.z );
+				gl_PointSize = size * ( 325.0 / -mvPosition.z );
+
+				vColor *= ( 125.0 / -mvPosition.z );
 
 				gl_Position = projectionMatrix * mvPosition;
 
 			}
+
 
 
 
@@ -45,7 +48,6 @@ void main() {
     gl_FragColor = vec4( vColor, 1.0 );
 
     gl_FragColor = gl_FragColor * texture2D( pointTexture, gl_PointCoord );
-
 }
 
 

--- a/client/index.html
+++ b/client/index.html
@@ -3,14 +3,8 @@
 <head>
     <meta charset="UTF-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
-    <link href="https://fonts.googleapis.com" rel="preconnect">
-    <link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
     <script src="./vendor/fa-6/js/all.min.js"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500&display=swap" rel="stylesheet">
-    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
-    <title>Udap</title>
+    <title>UDAP</title>
 </head>
 <body>
 
@@ -33,10 +27,6 @@
 
 			}
 
-
-
-
-
 </script>
 <script id="fshader" type="x-shader/x-fragment">
 uniform sampler2D pointTexture;
@@ -52,12 +42,11 @@ void main() {
 
 
 
+
 </script>
 <div id="app">
     <div class="simple-keyboard"></div>
 </div>
-
 <script src="./src/main.ts" type="module"></script>
 </body>
-
 </html>

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
     "bootstrap": "^5.1.0",
     "glob": "^8.0.1",
     "minimist": "~1.2.6",
-    "moment": "^2.29.2",
+    "moment": "^2.29.4",
     "qrcanvas-vue": "^3.0.0",
     "qrcode": "^1.5.0",
     "sass": "^1.45.1",

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -4,10 +4,16 @@ import {onMounted, provide, reactive, watch} from "vue";
 import {version} from "../package.json";
 
 
-interface Preferences {
+export interface Preferences {
   ui: {
-    blurBg: boolean
-    background: string
+    screensaver: {
+      enabled: boolean
+      countdown: number
+    }
+    background: {
+      image: string,
+      blur: boolean
+    }
     theme: string
     mode: string
     blur: number
@@ -21,9 +27,15 @@ interface Preferences {
 
 const preferenceDefaults: Preferences = {
   ui: {
-    blurBg: false,
+    screensaver: {
+      enabled: true,
+      countdown: 60 * 5
+    },
+    background: {
+      image: "milk",
+      blur: true
+    },
     blur: 6,
-    background: "milk",
     mode: "cursor",
     theme: "dark",
     brightness: 100,
@@ -40,7 +52,10 @@ function restore() {
   let stored = localStorage.getItem("preferences")
   if (stored) {
     let parsed: Preferences = JSON.parse(stored)
+    save(parsed)
     return parsed
+  } else {
+    save(preferenceDefaults)
   }
   return preferenceDefaults
 }
@@ -63,7 +78,6 @@ let state = reactive({
   countdown: 3,
   context: false,
   remote: {},
-
   system: {
     nexus: {
       system: {
@@ -76,6 +90,10 @@ let state = reactive({
       }
     }
   }
+})
+
+onMounted(() => {
+  resetCountdown()
 })
 
 let screensaver = reactive({
@@ -93,14 +111,14 @@ function forceScreensaver() {
 }
 
 function resetCountdown() {
-  screensaver.countdown = 60 * 5
+  screensaver.countdown = preferences.ui.screensaver.countdown
   screensaver.hideTerminal = false
   screensaver.show = false
   if (screensaver.interval !== 0) {
     clearInterval(screensaver.interval)
     screensaver.interval = 0
   }
-  if (!preferences.ui.outlines) return
+  if (!preferences.ui.screensaver.enabled) return
   screensaver.interval = setInterval(() => {
     screensaver.countdown -= 1;
     if (screensaver.countdown <= 0) {
@@ -114,47 +132,9 @@ function resetCountdown() {
   }, 1000)
 }
 
-onMounted(() => {
-  resetCountdown()
-  state.context = false
-  state.fps = 0
-})
 
 provide('system', state.system)
-
-function handleUpdate() {
-  if (state.countdown <= 0) {
-    clearInterval(state.timeout)
-    state.timeout = 0
-    state.hideHome = false
-  }
-}
-
-let lastReset = performance.now()
-let totalFrames = 0
-
-function tick() {
-  totalFrames++
-  let now = performance.now()
-  let dFps = totalFrames / ((now - lastReset) / 1000.0)
-  state.fps = Math.round(dFps * 10) / 10
-  if (totalFrames > 2000) {
-    totalFrames = 0
-    lastReset = performance.now()
-  }
-}
-
-function hideHome(hide: boolean) {
-  state.hideHome = hide
-}
-
-function toggleContext(hide: boolean) {
-  state.context = hide
-}
-
 provide('ui', preferences.ui)
-provide('context', toggleContext)
-provide('hideHome', hideHome)
 
 
 </script>
@@ -163,7 +143,8 @@ provide('hideHome', hideHome)
   <div
       :class="`${preferences.ui.night?'night-vision':''} theme-${preferences.ui.theme} mode-${preferences.ui.mode} blurs-${preferences.ui.blur} brightness-${preferences.ui.brightness}`"
       class="root" v-on:mousedown="(e) => resetCountdown()">
-    <img :class="`${preferences.ui.blurBg?'backdrop-blurred':''}`" :src="`/custom/${preferences.ui.background}@4x.png`"
+    <img :class="`${preferences.ui.background.blur?'backdrop-blurred':''}`"
+         :src="`/custom/${preferences.ui.background.image}@4x.png`"
          alt="Background" class="backdrop "/>
     <div v-if="preferences.ui.watermark" class="watermark">
       <div class="d-flex gap">

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -134,7 +134,7 @@ function resetCountdown() {
 
 
 provide('system', state.system)
-provide('ui', preferences.ui)
+provide('preferences', preferences)
 
 
 </script>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -164,6 +164,7 @@ provide('ui', preferences.ui)
     <div v-if="preferences.ui.grid" class="grid"></div>
 
     <div v-if="state.context" class="context context-light"></div>
+
     <router-view/>
 
 
@@ -172,6 +173,15 @@ provide('ui', preferences.ui)
 </template>
 
 <style lang="scss">
+.overlay-notification {
+  position: fixed;
+  z-index: 1;
+  height: 4.5rem;
+  width: 15rem;
+  padding: 1rem;
+  right: 0;
+  top: 0;
+}
 
 .screensaver-text {
   animation: screensaverTextLoadIn 500ms ease-in forwards;

--- a/client/src/components/IdTag.vue
+++ b/client/src/components/IdTag.vue
@@ -6,6 +6,7 @@ import Loader from "@/components/Loader.vue";
 import Plot from "@/components/plot/Plot.vue";
 import Toggle from "@/components/plot/Toggle.vue";
 import type {Remote} from "@/types";
+import type {Preferences} from "@/App.vue";
 
 let state = reactive({
   menu: false,
@@ -13,7 +14,7 @@ let state = reactive({
   connected: false,
 })
 
-let ui: any = inject("ui")
+let ui = inject("ui") as Preferences
 let remote: Remote = inject('remote') as Remote
 let system: any = inject('system')
 
@@ -140,7 +141,8 @@ function reload() {
     </Plot>
     <Plot :cols="2" :rows="2" title="Quick Settings">
       <Toggle :active="ui.grid" :fn="() => ui.grid = !ui.grid" title="Grid"></Toggle>
-      <Toggle :active="ui.outlines" :fn="() => ui.outlines = !ui.outlines" title="Screensaver"></Toggle>
+      <Toggle :active="ui.screensaver.enabled" :fn="() => ui.screensaver.enabled = !ui.screensaver.enabled"
+              title="Screensaver"></Toggle>
       <Toggle :active="ui.watermark" :fn="() => ui.watermark = !ui.watermark" title="Watermark"></Toggle>
       <Toggle :active="ui.blurBg" :fn="() => ui.blurBg = !ui.blurBg" title="Bg Blur"></Toggle>
     </Plot>

--- a/client/src/components/IdTag.vue
+++ b/client/src/components/IdTag.vue
@@ -14,7 +14,7 @@ let state = reactive({
   connected: false,
 })
 
-let ui = inject("ui") as Preferences
+let preferences: Preferences = inject("preferences") as Preferences
 let remote: Remote = inject('remote') as Remote
 let system: any = inject('system')
 
@@ -131,7 +131,7 @@ function reload() {
       </div>
     </Plot>
     <Plot :cols="1" :rows="1" title="Brightness">
-      <input v-model="ui.brightness"
+      <input v-model="preferences.ui.brightness"
              :max=20
              :min=4
              :step=1
@@ -140,11 +140,15 @@ function reload() {
              @mousemove.stop>
     </Plot>
     <Plot :cols="2" :rows="2" title="Quick Settings">
-      <Toggle :active="ui.grid" :fn="() => ui.grid = !ui.grid" title="Grid"></Toggle>
-      <Toggle :active="ui.screensaver.enabled" :fn="() => ui.screensaver.enabled = !ui.screensaver.enabled"
+      <Toggle :active="preferences.ui.grid" :fn="() => preferences.ui.grid = !preferences.ui.grid"
+              title="Grid"></Toggle>
+      <Toggle :active="preferences.ui.screensaver.enabled"
+              :fn="() => preferences.ui.screensaver.enabled = !preferences.ui.screensaver.enabled"
               title="Screensaver"></Toggle>
-      <Toggle :active="ui.watermark" :fn="() => ui.watermark = !ui.watermark" title="Watermark"></Toggle>
-      <Toggle :active="ui.blurBg" :fn="() => ui.blurBg = !ui.blurBg" title="Bg Blur"></Toggle>
+      <Toggle :active="preferences.ui.watermark" :fn="() => preferences.ui.watermark = !preferences.ui.watermark"
+              title="Watermark"></Toggle>
+      <Toggle :active="preferences.ui.background.blur"
+              :fn="() => preferences.ui.background.blur = !preferences.ui.background.blur" title="Bg Blur"></Toggle>
     </Plot>
 
   </div>

--- a/client/src/components/plot/Plot.vue
+++ b/client/src/components/plot/Plot.vue
@@ -15,7 +15,7 @@ let props = defineProps<Plot>()
   <div class="element element-group">
     <div v-if="props.title" class="d-flex align-items-center justify-content-between">
       <div class="label-c1  label-o4 label-w500 px-1 pb-1">{{ props.title }}</div>
-      <div class="label-c2 label-w500 label-r label-o2 px-1">{{ props.alt }}</div>
+      <div class="label-c2 label-w500 label-r label-o2 px-1" v-html="props.alt"></div>
     </div>
     <div :class="`${props.small?'plot-sm':'plot'}`" class="">
       <slot></slot>

--- a/client/src/components/plot/Radio.vue
+++ b/client/src/components/plot/Radio.vue
@@ -46,7 +46,7 @@ function up() {
 
 <template>
   <div :class="`${props.active?'active':''}`" class="radio subplot d-flex justify-content-center"
-       @mousedown="handle" @mouseleave="(e) => up()" @mouseout="(e) => up()" @mouseup="(e) => up()">
+       @click="(e) => props.fn()">
     <div><span v-if="props.icon"><i :class="`fa-${props.icon}`" class="fa-solid "></i>&nbsp;</span>{{ props.title }}
       <div v-if="props.sf" class="label-o3 label-c2" v-html="props.sf"></div>
     </div>

--- a/client/src/components/plot/Subplot.vue
+++ b/client/src/components/plot/Subplot.vue
@@ -18,12 +18,14 @@ const props = defineProps<Props>()
 </script>
 
 <template>
-  <div v-if="props.to" :class="`${props.to===$router.currentRoute.value.fullPath?'':'subplot-inline'}`"
+  <div v-if="props.to"
+       :class="`${props.to===$router.currentRoute.value.fullPath?'':'subplot-inline'} ${props.theme?`theme-${props.theme}`:''}`"
        class="subplot p-1"
        @mouseover="$router.replace(props.to || '/')">
     <div class="d-flex justify-content-start px-1">
-      <div class="label-w500 label-o3 label-c1"><i :class="`fa-solid fa-${props.icon} fa-fw`"></i></div>
-      <div class="label-w500 label-c1 px-2">{{ props.name }}</div>
+      <div v-if="props.icon" class="label-w500 label-o3 label-c1"><i :class="`fa-solid fa-${props.icon} fa-fw`"></i>
+      </div>
+      <div class="label-w500 label-c1 px-2 text-center">{{ props.name }}</div>
     </div>
 
     <slot></slot>
@@ -36,7 +38,7 @@ const props = defineProps<Props>()
          class="d-flex ">
       <div v-if="props.icon" class="label-w500 label-o3 label-c1"><i :class="`fa-solid fa-${props.icon} fa-fw`"></i>
       </div>
-      <div class="label-w500 label-c1 px-2 text-center">{{ props.name }}</div>
+      <div class="label-w500 label-c1 px-2 label-o4 text-center">{{ props.name }}</div>
       <div v-if="props.alt" class="label-w400 label-o4 label-c1 px-2">{{ props.alt }}</div>
 
 

--- a/client/src/components/plot/Subplot.vue
+++ b/client/src/components/plot/Subplot.vue
@@ -38,6 +38,7 @@ const props = defineProps<Props>()
          class="d-flex ">
       <div v-if="props.icon" class="label-w500 label-o3 label-c1"><i :class="`fa-solid fa-${props.icon} fa-fw`"></i>
       </div>
+      <div v-if="sf" v-html="sf"></div>
       <div class="label-w500 label-c1 px-2 label-o4 text-center">{{ props.name }}</div>
       <div v-if="props.alt" class="label-w400 label-o4 label-c1 px-2">{{ props.alt }}</div>
 

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -9,6 +9,7 @@ import Settings from "@/views/terminal/settings/Settings.vue";
 import Preferences from "@/views/terminal/settings/Preferences.vue";
 import Connection from "@/views/terminal/settings/Connection.vue";
 import Modules from "@/views/terminal/settings/module/Modules.vue";
+
 import Endpoints from "@/views/terminal/settings/endpoint/Endpoints.vue";
 import Timings from "@/views/terminal/settings/Timings.vue";
 import Zones from "@/views/terminal/settings/zone/Zones.vue";

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -117,11 +117,14 @@ export interface Attribute {
 export interface Device {
     created: string;
     updated: string;
+    state: string;
     id: string;
     networkId: string;
     entityId: string;
     name: string;
     hostname: string;
+    lastSeen: string;
+    latency: number;
     mac: string;
     ipv4: string;
     ipv6: string;

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -114,6 +114,26 @@ export interface Attribute {
     order: number;
 }
 
+export interface Utilization {
+    memory: {
+        total: number;
+        used: number;
+    };
+    network: {
+        hostname: string;
+        ipv4: string;
+        mac: string;
+    };
+    cpu: {
+        cores: number;
+        usage: number[];
+    };
+    disk: {
+        total: number;
+        used: number;
+    };
+}
+
 export interface Device {
     created: string;
     updated: string;
@@ -123,6 +143,8 @@ export interface Device {
     entityId: string;
     name: string;
     hostname: string;
+    utilization: Utilization;
+    isQueryable: boolean
     lastSeen: string;
     latency: number;
     mac: string;

--- a/client/src/views/screensaver/Screensaver.vue
+++ b/client/src/views/screensaver/Screensaver.vue
@@ -53,6 +53,7 @@ let depth = 1500
 function initCamera() {
   // Initialize Camera
   camera = new THREE.PerspectiveCamera(75, width / height, 1, depth * 1.5)
+
   camera.position.set(0, 0, 1);
   camera.lookAt(0, 0, 0)
 }
@@ -89,14 +90,14 @@ function initGraphics() {
   // Assign resize function
   element.onresize = resizeFrame
   // Initialize Stats manager
-  stats = new Stats();
-  element.appendChild(stats.dom)
+  // stats = new Stats();
+  // element.appendChild(stats.dom)
   // Set up the camera
   initCamera()
   // Set up the scene
   initScene()
   const renderScene = new RenderPass(scene, camera);
-  const bloomPass = new UnrealBloomPass(new THREE.Vector2(width, height), 1, 0.8, 0.3);
+  const bloomPass = new UnrealBloomPass(new THREE.Vector2(width, height), 2, 0.8, 0.3);
   const renderTargetParameters = {
     minFilter: THREE.LinearFilter,
     magFilter: THREE.LinearFilter,
@@ -146,6 +147,7 @@ function initScene() {
   }
 
   scene.add(objs)
+
   // scene.add(new THREE.AmbientLight(0x444444, 4));
   scene.background = new THREE.Color(0x000000);
 
@@ -155,7 +157,7 @@ function initScene() {
 function animate() {
   animationFrame = requestAnimationFrame(animate);
   render()
-  stats.update()
+  // stats.update()
   composer.render();
 }
 
@@ -203,7 +205,7 @@ function generateStars(): THREE.Object3D {
     colorArray[i3 + 1] = arr[1] / 255
     colorArray[i3 + 2] = arr[2] / 255
 
-    scaleArray[i] = 2 + Math.random() * 8;
+    scaleArray[i] = 2 + Math.random() * 10;
 
 
   }
@@ -237,7 +239,7 @@ function generateStars(): THREE.Object3D {
 
 function render() {
   // particleSystem.translateZ(1)
-  objs.children.forEach(c => c.translateZ(5))
+  objs.children.forEach(c => c.translateZ(2))
   for (let i = 0; i < objs.children.length; i++) {
     if (objs.children[i].position.z >= depth) {
       objs.children[i].position.setZ(-depth * numSections)

--- a/client/src/views/screensaver/Screensaver.vue
+++ b/client/src/views/screensaver/Screensaver.vue
@@ -20,15 +20,18 @@ let stats = {} as Stats
 let scene = {} as THREE.Scene
 let instanceMaterial = {} as THREE.RawShaderMaterial
 let objs = {} as THREE.Object3D
+let animationFrame = 0;
 
 onMounted(() => {
   reset()
   initGraphics()
 })
 
+
 onUnmounted(() => {
   instanceMaterial.dispose()
   renderer.dispose()
+  cancelAnimationFrame(animationFrame)
   reset()
 })
 
@@ -57,6 +60,7 @@ function initCamera() {
 // Handler resizing the viewport if and when the viewport is altered
 function resizeFrame() {
   camera.aspect = width / height;
+  if (!camera) return
   camera.updateProjectionMatrix();
 
   renderer.setSize(width, height);
@@ -83,7 +87,7 @@ function initGraphics() {
   // Add the renderer to the dom
   element.appendChild(renderer.domElement)
   // Assign resize function
-  window.onresize = resizeFrame
+  element.onresize = resizeFrame
   // Initialize Stats manager
   stats = new Stats();
   element.appendChild(stats.dom)
@@ -149,7 +153,7 @@ function initScene() {
 
 // Define animation routine
 function animate() {
-  requestAnimationFrame(animate);
+  animationFrame = requestAnimationFrame(animate);
   render()
   stats.update()
   composer.render();
@@ -183,15 +187,8 @@ function generateStars(): THREE.Object3D {
   let scaleArray = new Float32Array(particleCount);
   let particleGeometry = new THREE.BufferGeometry();
 
-
-  let aspectW = (width / height) * 3
-  let aspectH = (height / width) * 4.5
-
-  const radius = 200;
   let mean = 2747.5 + 100
   let sd = 1509.878
-
-  let wave = 0.2;
 
   for (let i = 0, i3 = 0, l = particleCount; i < l; i++, i3 += 3) {
 

--- a/client/src/views/screensaver/Screensaver.vue
+++ b/client/src/views/screensaver/Screensaver.vue
@@ -4,7 +4,6 @@
 
 import * as THREE from "three";
 import {onMounted, onUnmounted} from "vue";
-import Stats from 'stats.js';
 import {RenderPass} from "three/examples/jsm/postprocessing/RenderPass";
 import {UnrealBloomPass} from "three/examples/jsm/postprocessing/UnrealBloomPass";
 import {EffectComposer} from "three/examples/jsm/postprocessing/EffectComposer";
@@ -16,7 +15,6 @@ import {BlendShader} from "three/examples/jsm/shaders/BlendShader";
 let renderer = {} as THREE.WebGLRenderer
 let camera = {} as THREE.PerspectiveCamera
 let composer = {} as EffectComposer
-let stats = {} as Stats
 let scene = {} as THREE.Scene
 let instanceMaterial = {} as THREE.RawShaderMaterial
 let objs = {} as THREE.Object3D
@@ -40,7 +38,6 @@ function reset() {
   camera = {} as THREE.PerspectiveCamera
   composer = {} as EffectComposer
   scene = {} as THREE.Scene
-  stats = {} as Stats
   instanceMaterial = {} as THREE.RawShaderMaterial
   objs = {} as THREE.Object3D
 }

--- a/client/src/views/terminal/Energy.vue
+++ b/client/src/views/terminal/Energy.vue
@@ -170,7 +170,7 @@ $blue: #3498db;
 $grey: #f2f2f2;
 
 @function rem($val) {
-  @return #{$val / $baseFontSize}rem;
+  @return #{calc($val / $baseFontSize)}rem;
 }
 
 // Gauge

--- a/client/src/views/terminal/settings/Preferences.vue
+++ b/client/src/views/terminal/settings/Preferences.vue
@@ -7,25 +7,13 @@ import {PreferenceTypes} from "@/types";
 import Plot from "@/components/plot/Plot.vue";
 import axios from "axios";
 import Subplot from "@/components/plot/Subplot.vue";
-
-interface Preferences {
-  ui: {
-    background: string
-    theme: string
-    mode: string
-    blur: number
-    grid: boolean
-    watermark: boolean
-    night: boolean
-    outlines: boolean
-  }
-}
+import type {Preferences} from "@/App.vue";
 
 let state = reactive({
   loading: true,
 })
 
-const preferences = inject("preferences") as Preferences
+let preferences = inject("preferences") as Preferences
 
 const defaults = {
   backgrounds: [
@@ -106,7 +94,7 @@ function changeBackground(name: string): any {
   new Preference(PreferenceTypes.Background).set(name)
   state.loading = true
   loadImage(name);
-  preferences.ui.background = name
+  preferences.ui.background.image = name
 }
 
 function changeTheme(name: string): any {
@@ -129,7 +117,7 @@ function changeTouchmode(mode: string): any {
         <Plot :cols="5" :rows="2" title="Background">
           <div v-for="background in defaults.backgrounds" @click="changeBackground(background.identifier)">
             <div class=" w-100 d-flex justify-content-start subplot " style="padding: 0.125rem;">
-              <div :class="`${preferences.ui.background === background.identifier?'active':''}`"
+              <div :class="`${preferences.ui.background.image === background.identifier?'active':''}`"
                    :style="`background-image: url('/custom/${background.identifier}@2x.png');`"
                    class="background-preview ">
                 <div class="label-xxs label-w500 label-o5 pb-1">

--- a/client/src/views/terminal/settings/device/Device.vue
+++ b/client/src/views/terminal/settings/device/Device.vue
@@ -1,0 +1,16 @@
+<!-- Copyright (c) 2022 Braden Nicholson -->
+<script lang="ts" setup>
+
+
+</script>
+
+<template>
+  <div class="h-100">
+    <router-view/>
+  </div>
+</template>
+
+<style scoped>
+
+
+</style>

--- a/client/src/views/terminal/settings/device/DeviceOverview.vue
+++ b/client/src/views/terminal/settings/device/DeviceOverview.vue
@@ -6,7 +6,6 @@ import Plot from "@/components/plot/Plot.vue";
 import Radio from "@/components/plot/Radio.vue";
 import Loader from "@/components/Loader.vue";
 import axios from "axios";
-import Subplot from "@/components/plot/Subplot.vue";
 
 let remote = inject("remote") as Remote
 let preferences = inject('preferences')
@@ -122,9 +121,12 @@ function rename(name: string, device: Device) {
             </div>
 
           </div>
-          <div class="d-flex gap-1 text-success justify-content-center">
-            <Subplot :active="true" :fn="() => $router.push(`/terminal/settings/devices/${device.id}`)"
-                     name="Configure" sf="cog" style="width: 100%;"></Subplot>
+          <div class="d-flex justify-content-start gap-1">
+            <Radio :active="false" :fn="() => $router.push(`/terminal/settings/devices/${device.id}/configure`)" sf="􀍟"
+                   style="width: 2.5rem;" title=""></Radio>
+            <Radio v-if="device.isQueryable" :active="false"
+                   :fn="() => $router.push(`/terminal/settings/devices/${device.id}/monitor`)" sf="􀜟"
+                   style="width: 2.5rem;" title=""></Radio>
 
           </div>
         </Plot>

--- a/client/src/views/terminal/settings/device/DeviceOverview.vue
+++ b/client/src/views/terminal/settings/device/DeviceOverview.vue
@@ -1,0 +1,219 @@
+<!-- Copyright (c) 2022 Braden Nicholson -->
+<script lang="ts" setup>
+import {inject, onMounted, reactive, watchEffect} from "vue";
+import type {Device, Remote} from "@/types";
+import Plot from "@/components/plot/Plot.vue";
+import Radio from "@/components/plot/Radio.vue";
+import Loader from "@/components/Loader.vue";
+import axios from "axios";
+import Subplot from "@/components/plot/Subplot.vue";
+
+let remote = inject("remote") as Remote
+let preferences = inject('preferences')
+
+let state = reactive({
+  devices: {} as Device[],
+  histories: new Map<string, number[]>(),
+  maxes: new Map<string, number>(),
+  loading: true,
+  mode: "list"
+})
+
+
+onMounted(() => {
+  state.loading = true
+  handleUpdates(remote)
+})
+
+watchEffect(() => handleUpdates(remote))
+
+function sortAlpha(a: Device, b: Device) {
+  if (a.name > b.name) {
+    return -1
+  } else {
+    return 1
+  }
+}
+
+function handleUpdates(remote: Remote) {
+  state.devices = remote.devices
+  state.devices = state.devices.sort(sortAlpha)
+  state.devices.forEach(t => {
+    let local = state.histories.get(t.mac) || []
+    let cand = t.latency / 1000
+    if (local.includes(cand)) return
+    local.push(cand)
+    if (local.length > 20) {
+      local = local.slice(1)
+    }
+    state.histories.set(t.mac, local)
+  })
+  state.loading = false
+  return remote
+}
+
+function setMode(mode: string) {
+  state.mode = mode
+}
+
+function isOnline(ns: string): boolean {
+  return (new Date().valueOf() - new Date(ns).valueOf()) < 30 * 1000
+}
+
+function nsToMs(ns: number): number {
+  return Math.round(ns / 1000 / 1000 * 10) / 10
+}
+
+function rename(name: string, device: Device) {
+  device.name = name
+  axios.post("http://10.0.1.18:3020/devices/update", JSON.stringify(device))
+}
+
+</script>
+
+<template>
+  <div v-if="!state.loading">
+    <div class="d-flex justify-content-start py-2 px-1">
+      <div class="label-w500 label-o4 label-xxl"><i :class="`fa-solid fa-expand fa-fw`"></i></div>
+      <div class="label-w500 opacity-100 label-xxl px-2">Devices</div>
+      <div class="flex-fill"></div>
+
+      <Plot :cols="1" :rows="1" small style="width: 6rem;">
+        <Radio :active="false" :fn="() => setMode(state.mode === 'create'?'list':'create')"
+               :title="state.mode === 'create'?'Cancel':'New Endpoint'"></Radio>
+      </Plot>
+    </div>
+    <div v-if="state.mode === 'list'">
+
+      <div class="device-container">
+        <Plot v-for="device in state.devices" :cols="2" :rows="1">
+          <div class="subplot subplot-inline justify-content-between px-0 w-100">
+            <div class="d-flex align-items-center">
+              <div :style="`background-color: rgba(${device.state==='ONLINE'?'25, 135, 84':'135, 100, 2'}, 0.53);`"
+                   class="status-marker"></div>
+              <div>
+                <div class="label-c1 label-o4 label-r lh-1 w-100">
+                  <div>{{ device.name || device.ipv4 }}</div>
+                </div>
+                <div class="label-c4  label-o3 label-r py-0 w-100 d-flex justify-content-between"
+                     style="line-height: 0.55rem">
+                  {{ device.mac }}
+
+                </div>
+
+
+              </div>
+            </div>
+
+            <div class="label-c3 label-o4 d-flex flex-column justify-content-end align-items-end">
+              <div :class="`${ device.state === 'ONLINE'?'text-success':''}`" class="label-o3">
+                &nbsp;{{ device.state === "ONLINE" ? `${nsToMs(device.latency)} ms` : device.state }}
+              </div>
+              <div class="d-flex gap-1">
+
+                <div v-if="state.histories" class="label-c3 label-o3 d-flex flex-row align-items-end time-marker-line">
+
+                  <div v-for="marker in state.histories.get(device.mac)?.map(d => d / 1000)"
+                       :style="`height:${Math.log(marker)}px;`"
+                       class="time-marker"></div>
+                </div>
+              </div>
+
+            </div>
+
+          </div>
+          <div class="d-flex gap-1 text-success justify-content-center">
+            <Subplot :active="true" :fn="() => $router.push(`/terminal/settings/devices/${device.id}`)"
+                     name="Configure" sf="cog" style="width: 100%;"></Subplot>
+
+          </div>
+        </Plot>
+
+
+      </div>
+    </div>
+    <div v-else-if="state.mode === 'create'">
+      Create mode!
+    </div>
+  </div>
+
+  <div v-else>
+    <div class="d-flex justify-content-start py-2 px-1">
+      <div class="label-w500 label-o4 label-xxl"><i :class="`fa-solid fa-expand fa-fw`"></i></div>
+      <div class="label-w500 opacity-100 label-xxl px-2">Endpoints</div>
+      <div class="flex-fill"></div>
+
+    </div>
+    <div class="element p-2">
+      <div class="label-c1 label-o4 d-flex align-content-center gap-1">
+        <div>
+          <Loader size="sm"></Loader>
+        </div>
+        <div class="">Loading...</div>
+      </div>
+    </div>
+  </div>
+
+</template>
+
+<style scoped>
+
+.time-marker {
+  width: 2px;
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 2px;
+  height: 1px;
+}
+
+.time-marker-line {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  height: 20px;
+  width: 75px;
+  align-items: center;
+  gap: 1px;
+  border-radius: 6px;
+  background-color: hsla(214, 9%, 28%, 0.2);
+  padding: 6px
+}
+
+.overflow-ellipse {
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis !important;
+  text-wrap: none !important;
+  max-width: 34rem;
+}
+
+.device-container {
+  display: grid;
+  grid-column-gap: 0.25rem;
+  grid-row-gap: 0.25rem;
+  grid-auto-flow: column;
+  grid-template-rows: repeat(8, 1fr);
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.status-marker {
+  width: 4px !important;
+  border-radius: 4px;
+  height: 28px;
+
+  margin-right: 14px;
+  margin-left: 8px;
+
+
+  background-color: rgba(25, 135, 84, 0.53);
+}
+
+.device-unit {
+  padding: 0.25rem 0.5rem;
+  display: flex;
+  align-content: center;
+  align-items: center;
+}
+
+
+</style>

--- a/client/src/views/terminal/settings/device/RenameDevice.vue
+++ b/client/src/views/terminal/settings/device/RenameDevice.vue
@@ -1,0 +1,140 @@
+<!-- Copyright (c) 2022 Braden Nicholson -->
+<script lang="ts" setup>
+import {inject, onMounted, reactive, watchEffect} from "vue";
+import type {Device, Remote} from "@/types";
+import SimpleKeyboard from "@/components/Keyboard.vue";
+import axios from "axios";
+import router from "@/router";
+import {useRoute} from 'vue-router'
+
+interface NewZone {
+  name: string
+  user: string
+  entities: string[]
+}
+
+const route = useRoute()
+let remote = inject("remote") as Remote
+let preferences = inject('preferences')
+
+let state = reactive({
+  loading: true,
+  model: "",
+  mode: "name",
+  device: {} as Device,
+  name: "",
+})
+
+onMounted(() => {
+  state.loading = true
+  handleUpdates(remote)
+})
+
+watchEffect(() => handleUpdates(remote))
+
+function handleUpdates(remote: Remote) {
+  state.device = remote.devices.find(device => device.id === route.params.device) as Device
+  if (!state.device) return
+  state.loading = false
+  return remote.entities
+}
+
+interface CreateZoneProps {
+  done: () => {}
+}
+
+let props = defineProps<CreateZoneProps>();
+
+function enterChar(char: string) {
+  // If the incoming char is a backspace, decrement the cursor and clear the value.
+  if (char === "{bksp}") {
+    // Only decrement the cursor if it is bigger than zero
+    if (state.name.length > 0) state.name = state.name.slice(0, state.name.length - 1)
+    // Exit the function
+    return
+  }
+
+  char = char.replace("{space}", " ")
+  // Return if the security code block is full
+  if (state.name.length >= 64) return
+  // Add the provided char to the cursor position
+  state.name += char
+}
+
+function nextStep() {
+  state.mode = 'select'
+}
+
+function updateName(name: string, device: Device) {
+  device.name = name
+  let payload = JSON.stringify(device)
+  axios.post("http://10.0.1.18:3020/devices/update", payload).then(res => {
+    router.push("/terminal/settings/devices")
+  }).catch(err => {
+    console.log(err)
+  })
+
+
+}
+
+
+</script>
+
+<template>
+  <div v-if="!state.loading">
+    <div class="d-flex justify-content-start py-2 px-1">
+      <div class="label-w500 label-o4 label-xxl"><i :class="`fa-solid fa-share-nodes fa-fw`"></i></div>
+      <div class="label-w500 opacity-100 label-xxl px-2">Assign name for {{ state.device.ipv4 }}</div>
+      <div class="flex-fill"></div>
+    </div>
+
+    <div class="d-flex justify-content-center">
+      <div class="element p-2" style="width: 20rem;">
+        <div class="text-input w-100"
+             style="font-size: 0.9rem;">
+          <div v-html="state.name"></div>
+          <div class="cursor-blink"></div>
+          <div class="flex-fill"></div>
+          <div class="label-o3 label-c1" @mousedown="state.name = ''">
+            Clear
+          </div>
+        </div>
+      </div>
+      <div
+          class="element label-o3 label-c1 label-r d-flex justify-content-center align-items-center px-3 mx-1"
+          @click="() => updateName(state.name, state.device)">Rename</div>
+    </div>
+    <SimpleKeyboard :input="enterChar" class="position-absolute" keySet="d"
+                    keyboardClass="simple-keyboard"
+    ></SimpleKeyboard>
+
+  </div>
+  <div v-else-if="state.mode === 'select'" class="h-100">
+
+  </div>
+
+</template>
+
+<style lang="scss" scoped>
+.cursor-blink {
+  height: 1rem;
+  width: 2px;
+  border-radius: 2px;
+  background-color: rgba(255, 255, 255, 0.125);
+  margin-left: 2px;
+  animation: cursor-flash 1s ease infinite;
+}
+
+@keyframes cursor-flash {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.125;
+  }
+}
+
+</style>

--- a/client/src/views/terminal/settings/endpoint/Endpoints.vue
+++ b/client/src/views/terminal/settings/endpoint/Endpoints.vue
@@ -1,7 +1,7 @@
 <!-- Copyright (c) 2022 Braden Nicholson -->
 <script lang="ts" setup>
 import {inject, onMounted, reactive, watchEffect} from "vue";
-import type {Endpoint, Remote} from "@/types";
+import type {Device, Endpoint, Remote} from "@/types";
 import Plot from "@/components/plot/Plot.vue";
 import Radio from "@/components/plot/Radio.vue";
 
@@ -13,6 +13,7 @@ let preferences = inject('preferences')
 
 let state = reactive({
   endpoints: {} as Endpoint[],
+  devices: {} as Device[],
   loading: true,
   mode: "list"
 })
@@ -27,8 +28,9 @@ watchEffect(() => handleUpdates(remote))
 
 function handleUpdates(remote: Remote) {
   state.endpoints = remote.endpoints
+  state.devices = remote.devices
   state.loading = false
-  return remote.endpoints
+  return remote
 }
 
 function setMode(mode: string) {
@@ -39,6 +41,12 @@ function setMode(mode: string) {
 
 <template>
   <div v-if="!state.loading">
+    <div class="d-flex justify-content-between gap-1 w-100 flex-wrap">
+      <div v-for="device in state.devices" class="element">
+        <div class="label-o4 label-c1">{{ device.ipv4 }}</div>
+        <div class="label-o2 label-c1">{{ device.mac }}</div>
+      </div>
+    </div>
 
 
     <div class="d-flex justify-content-start py-2 px-1">

--- a/client/src/views/terminal/settings/index.ts
+++ b/client/src/views/terminal/settings/index.ts
@@ -11,6 +11,7 @@ import Zones from "@/views/terminal/settings/zone/Zones.vue";
 import Entities from "@/views/terminal/settings/entity/Entities.vue";
 import Devices from "@/views/terminal/settings/device/Device.vue";
 import DeviceOverview from "@/views/terminal/settings/device/DeviceOverview.vue";
+import DeviceMonitor from "@/views/terminal/settings/device/DeviceMonitor.vue";
 import RenameDevice from "@/views/terminal/settings/device/RenameDevice.vue";
 
 export default {
@@ -83,10 +84,16 @@ export default {
                         component: DeviceOverview,
                     },
                     {
-                        path: '/terminal/settings/devices/:device',
+                        path: '/terminal/settings/devices/:device/configure',
                         name: 'Edit Device',
                         icon: 'share-nodes',
                         component: RenameDevice,
+                    },
+                    {
+                        path: '/terminal/settings/devices/:device/monitor',
+                        name: 'Edit Device',
+                        icon: 'share-nodes',
+                        component: DeviceMonitor,
                     },
                 ]
             },

--- a/client/src/views/terminal/settings/index.ts
+++ b/client/src/views/terminal/settings/index.ts
@@ -9,6 +9,9 @@ import Timings from "@/views/terminal/settings/Timings.vue";
 import Zone from "@/views/terminal/settings/zone/Zone.vue";
 import Zones from "@/views/terminal/settings/zone/Zones.vue";
 import Entities from "@/views/terminal/settings/entity/Entities.vue";
+import Devices from "@/views/terminal/settings/device/Device.vue";
+import DeviceOverview from "@/views/terminal/settings/device/DeviceOverview.vue";
+import RenameDevice from "@/views/terminal/settings/device/RenameDevice.vue";
 
 export default {
     routes: {
@@ -58,18 +61,41 @@ export default {
             {
                 path: '/terminal/settings/entities',
                 name: 'Entities',
-                icon: 'expand',
+                icon: 'clone',
                 meta: {
                     order: 4,
                 },
                 component: Entities
             },
             {
+                path: '/terminal/settings/devices',
+                name: 'Devices',
+                icon: 'share-nodes',
+                meta: {
+                    order: 5,
+                },
+                component: Devices,
+                children: [
+                    {
+                        path: '/terminal/settings/devices',
+                        name: 'Device Overview',
+                        icon: 'share-nodes',
+                        component: DeviceOverview,
+                    },
+                    {
+                        path: '/terminal/settings/devices/:device',
+                        name: 'Edit Device',
+                        icon: 'share-nodes',
+                        component: RenameDevice,
+                    },
+                ]
+            },
+            {
                 path: '/terminal/settings/timings',
                 name: 'Timings',
                 icon: 'clock',
                 meta: {
-                    order: 5,
+                    order: 6,
                 },
                 component: Timings
             },
@@ -80,7 +106,7 @@ export default {
                 name: 'Zone',
                 icon: 'map',
                 meta: {
-                    order: 6,
+                    order: 7,
                 },
                 component: Zone,
                 children: [

--- a/client/src/views/terminal/settings/module/Modules.vue
+++ b/client/src/views/terminal/settings/module/Modules.vue
@@ -213,7 +213,7 @@ function groupBy<T>(xs: T[], key: string): T[] {
   align-items: center;
   gap: 1px;
   border-radius: 6px;
-  background-color: hsla(214, 9, 28, 0.2);
+  background-color: hsla(214, 9%, 28%, 0.2);
   padding: 6px
 }
 

--- a/client/src/views/terminal/settings/module/Modules.vue
+++ b/client/src/views/terminal/settings/module/Modules.vue
@@ -102,11 +102,7 @@ function groupBy<T>(xs: T[], key: string): T[] {
               <div class="w-100">
                 <div>
                   <div class="label-c1 label-o5 label-r lh-1">
-                    <div class="d-flex justify-content-between">
-                      <div>{{ module.name }}</div>
-
-                    </div>
-
+                    <div>{{ module.name }}</div>
                   </div>
                   <div class="label-c4  label-o3 label-r py-0 overflow-ellipse" style="line-height: 0.55rem">{{
                       module.description

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2,29 +2,29 @@
 # yarn lockfile v1
 
 
-"@babel/helper-validator-identifier@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
-  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+"@babel/helper-validator-identifier@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
+  integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
 
 "@babel/parser@^7.16.4", "@babel/parser@^7.6.0", "@babel/parser@^7.9.6":
-  version "7.18.4"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.4.tgz#6774231779dd700e0af29f6ad8d479582d7ce5ef"
-  integrity sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==
+  version "7.18.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.8.tgz#822146080ac9c62dac0823bb3489622e0bc1cbdf"
+  integrity sha512-RSKRfYX20dyH+elbJK2uqAkVyucL+xXzhqlMD5/ZXx+dAAwpyB7HsvnHe/ZUGOF+xLr5Wx9/JoXVTj6BQE2/oA==
 
 "@babel/runtime@^7.11.2", "@babel/runtime@^7.16.0":
-  version "7.18.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.3.tgz#c7b654b57f6f63cf7f8b418ac9ca04408c4579f4"
-  integrity sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.6.tgz#6a1ef59f838debd670421f8c7f2cbb8da9751580"
+  integrity sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==
   dependencies:
     regenerator-runtime "^0.13.4"
 
 "@babel/types@^7.6.1", "@babel/types@^7.9.6":
-  version "7.18.4"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.4.tgz#27eae9b9fd18e9dccc3f9d6ad051336f307be354"
-  integrity sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==
+  version "7.18.8"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.8.tgz#c5af199951bf41ba4a6a9a6d0d8ad722b30cd42f"
+  integrity sha512-qwpdsmraq0aJ3osLJRApsc2ouSJCdnMeZwB0DhbtHAtRpZNZCdlbRnHIgcRKzdE1g0iOGg644fzjOBcdOz9cPw==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
+    "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
 
 "@emmetio/abbreviation@^2.2.3":
@@ -59,9 +59,9 @@
     moment "^2.10.2"
 
 "@types/node@*":
-  version "17.0.40"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.40.tgz#76ee88ae03650de8064a6cf75b8d95f9f4a16090"
-  integrity sha512-UXdBxNGqTMtm7hCwh9HtncFVLrXoqA3oJW30j6XWp5BH/wu3mVeaxo7cq5benFdBw34HB3XDT2TRPI7rXZ+mDg==
+  version "18.0.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.3.tgz#463fc47f13ec0688a33aec75d078a0541a447199"
+  integrity sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ==
 
 "@types/stats.js@^0.17.0":
   version "0.17.0"
@@ -203,10 +203,10 @@
     "@vue/compiler-dom" "3.2.37"
     "@vue/shared" "3.2.37"
 
-"@vue/devtools-api@^6.0.0":
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.1.4.tgz#b4aec2f4b4599e11ba774a50c67fa378c9824e53"
-  integrity sha512-IiA0SvDrJEgXvVxjNkHPFfDx6SXw0b/TUkqMcDZWNg9fnCAHbTpoo59YfJ9QLFkwa3raau5vSlRVzMSLDnfdtQ==
+"@vue/devtools-api@^6.1.4":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.2.0.tgz#e3dc98a0cce8e87292745e2d24c9ee8c274a023b"
+  integrity sha512-pF1G4wky+hkifDiZSWn8xfuLOJI1ZXtuambpBEYaf7Xaf6zC/pM29rvAGpd3qaGXnr4BAXU1Pxz/VfvBGwexGA==
 
 "@vue/reactivity-transform@3.2.37":
   version "3.2.37"
@@ -504,131 +504,131 @@ entities@^3.0.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
   integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
 
-esbuild-android-64@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.42.tgz#d7ab3d44d3671218d22bce52f65642b12908d954"
-  integrity sha512-P4Y36VUtRhK/zivqGVMqhptSrFILAGlYp0Z8r9UQqHJ3iWztRCNWnlBzD9HRx0DbueXikzOiwyOri+ojAFfW6A==
+esbuild-android-64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.48.tgz#7e6394a0e517f738641385aaf553c7e4fb6d1ae3"
+  integrity sha512-3aMjboap/kqwCUpGWIjsk20TtxVoKck8/4Tu19rubh7t5Ra0Yrpg30Mt1QXXlipOazrEceGeWurXKeFJgkPOUg==
 
-esbuild-android-arm64@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.42.tgz#45336d8bec49abddb3a022996a23373f45a57c27"
-  integrity sha512-0cOqCubq+RWScPqvtQdjXG3Czb3AWI2CaKw3HeXry2eoA2rrPr85HF7IpdU26UWdBXgPYtlTN1LUiuXbboROhg==
+esbuild-android-arm64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.48.tgz#6877566be0f82dd5a43030c0007d06ece7f7c02f"
+  integrity sha512-vptI3K0wGALiDq+EvRuZotZrJqkYkN5282iAfcffjI5lmGG9G1ta/CIVauhY42MBXwEgDJkweiDcDMRLzBZC4g==
 
-esbuild-darwin-64@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.42.tgz#6dff5e44cd70a88c33323e2f5fb598e40c68a9e0"
-  integrity sha512-ipiBdCA3ZjYgRfRLdQwP82rTiv/YVMtW36hTvAN5ZKAIfxBOyPXY7Cejp3bMXWgzKD8B6O+zoMzh01GZsCuEIA==
+esbuild-darwin-64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.48.tgz#ea3caddb707d88f844b1aa1dea5ff3b0a71ef1fd"
+  integrity sha512-gGQZa4+hab2Va/Zww94YbshLuWteyKGD3+EsVon8EWTWhnHFRm5N9NbALNbwi/7hQ/hM1Zm4FuHg+k6BLsl5UA==
 
-esbuild-darwin-arm64@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.42.tgz#2c7313e1b12d2fa5b889c03213d682fb92ca8c4f"
-  integrity sha512-bU2tHRqTPOaoH/4m0zYHbFWpiYDmaA0gt90/3BMEFaM0PqVK/a6MA2V/ypV5PO0v8QxN6gH5hBPY4YJ2lopXgA==
+esbuild-darwin-arm64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.48.tgz#4e5eaab54df66cc319b76a2ac0e8af4e6f0d9c2f"
+  integrity sha512-bFjnNEXjhZT+IZ8RvRGNJthLWNHV5JkCtuOFOnjvo5pC0sk2/QVk0Qc06g2PV3J0TcU6kaPC3RN9yy9w2PSLEA==
 
-esbuild-freebsd-64@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.42.tgz#ad1c5a564a7e473b8ce95ee7f76618d05d6daffc"
-  integrity sha512-75h1+22Ivy07+QvxHyhVqOdekupiTZVLN1PMwCDonAqyXd8TVNJfIRFrdL8QmSJrOJJ5h8H1I9ETyl2L8LQDaw==
+esbuild-freebsd-64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.48.tgz#47b5abc7426eae66861490ffbb380acc67af5b15"
+  integrity sha512-1NOlwRxmOsnPcWOGTB10JKAkYSb2nue0oM1AfHWunW/mv3wERfJmnYlGzL3UAOIUXZqW8GeA2mv+QGwq7DToqA==
 
-esbuild-freebsd-arm64@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.42.tgz#4bdb480234144f944f1930829bace7561135ddc7"
-  integrity sha512-W6Jebeu5TTDQMJUJVarEzRU9LlKpNkPBbjqSu+GUPTHDCly5zZEQq9uHkmHHl7OKm+mQ2zFySN83nmfCeZCyNA==
+esbuild-freebsd-arm64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.48.tgz#e8c54c8637cd44feed967ea12338b0a4da3a7b11"
+  integrity sha512-gXqKdO8wabVcYtluAbikDH2jhXp+Klq5oCD5qbVyUG6tFiGhrC9oczKq3vIrrtwcxDQqK6+HDYK8Zrd4bCA9Gw==
 
-esbuild-linux-32@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.42.tgz#ef18fd19f067e9d2b5f677d6b82fa81519f5a8c2"
-  integrity sha512-Ooy/Bj+mJ1z4jlWcK5Dl6SlPlCgQB9zg1UrTCeY8XagvuWZ4qGPyYEWGkT94HUsRi2hKsXvcs6ThTOjBaJSMfg==
+esbuild-linux-32@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.48.tgz#229cf3246de2b7937c3ac13fac622d4d7a1344c5"
+  integrity sha512-ghGyDfS289z/LReZQUuuKq9KlTiTspxL8SITBFQFAFRA/IkIvDpnZnCAKTCjGXAmUqroMQfKJXMxyjJA69c/nQ==
 
-esbuild-linux-64@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.42.tgz#d84e7333b1c1b22cf8b5b9dbb5dd9b2ecb34b79f"
-  integrity sha512-2L0HbzQfbTuemUWfVqNIjOfaTRt9zsvjnme6lnr7/MO9toz/MJ5tZhjqrG6uDWDxhsaHI2/nsDgrv8uEEN2eoA==
+esbuild-linux-64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.48.tgz#7c0e7226c02c42aacc5656c36977493dc1e96c4f"
+  integrity sha512-vni3p/gppLMVZLghI7oMqbOZdGmLbbKR23XFARKnszCIBpEMEDxOMNIKPmMItQrmH/iJrL1z8Jt2nynY0bE1ug==
 
-esbuild-linux-arm64@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.42.tgz#dc19e282f8c4ffbaa470c02a4d171e4ae0180cca"
-  integrity sha512-c3Ug3e9JpVr8jAcfbhirtpBauLxzYPpycjWulD71CF6ZSY26tvzmXMJYooQ2YKqDY4e/fPu5K8bm7MiXMnyxuA==
+esbuild-linux-arm64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.48.tgz#0af1eda474b5c6cc0cace8235b74d0cb8fcf57a7"
+  integrity sha512-3CFsOlpoxlKPRevEHq8aAntgYGYkE1N9yRYAcPyng/p4Wyx0tPR5SBYsxLKcgPB9mR8chHEhtWYz6EZ+H199Zw==
 
-esbuild-linux-arm@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.42.tgz#d49870e63e2242b8156bf473f2ee5154226be328"
-  integrity sha512-STq69yzCMhdRaWnh29UYrLSr/qaWMm/KqwaRF1pMEK7kDiagaXhSL1zQGXbYv94GuGY/zAwzK98+6idCMUOOCg==
+esbuild-linux-arm@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.48.tgz#de4d1fa6b77cdcd00e2bb43dd0801e4680f0ab52"
+  integrity sha512-+VfSV7Akh1XUiDNXgqgY1cUP1i2vjI+BmlyXRfVz5AfV3jbpde8JTs5Q9sYgaoq5cWfuKfoZB/QkGOI+QcL1Tw==
 
-esbuild-linux-mips64le@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.42.tgz#f4e6ff9bf8a6f175470498826f48d093b054fc22"
-  integrity sha512-QuvpHGbYlkyXWf2cGm51LBCHx6eUakjaSrRpUqhPwjh/uvNUYvLmz2LgPTTPwCqaKt0iwL+OGVL0tXA5aDbAbg==
+esbuild-linux-mips64le@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.48.tgz#822c1778495f7868e990d4da47ad7281df28fd15"
+  integrity sha512-cs0uOiRlPp6ymknDnjajCgvDMSsLw5mST2UXh+ZIrXTj2Ifyf2aAP3Iw4DiqgnyYLV2O/v/yWBJx+WfmKEpNLA==
 
-esbuild-linux-ppc64le@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.42.tgz#ac9c66fc80ba9f8fda15a4cc08f4e55f6c0aed63"
-  integrity sha512-8ohIVIWDbDT+i7lCx44YCyIRrOW1MYlks9fxTo0ME2LS/fxxdoJBwHWzaDYhjvf8kNpA+MInZvyOEAGoVDrMHg==
+esbuild-linux-ppc64le@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.48.tgz#55de0a9ec4a48fedfe82a63e083164d001709447"
+  integrity sha512-+2F0vJMkuI0Wie/wcSPDCqXvSFEELH7Jubxb7mpWrA/4NpT+/byjxDz0gG6R1WJoeDefcrMfpBx4GFNN1JQorQ==
 
-esbuild-linux-riscv64@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.42.tgz#21e0ae492a3a9bf4eecbfc916339a66e204256d0"
-  integrity sha512-DzDqK3TuoXktPyG1Lwx7vhaF49Onv3eR61KwQyxYo4y5UKTpL3NmuarHSIaSVlTFDDpcIajCDwz5/uwKLLgKiQ==
+esbuild-linux-riscv64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.48.tgz#cd2b7381880b2f4b21a5a598fb673492120f18a5"
+  integrity sha512-BmaK/GfEE+5F2/QDrIXteFGKnVHGxlnK9MjdVKMTfvtmudjY3k2t8NtlY4qemKSizc+QwyombGWTBDc76rxePA==
 
-esbuild-linux-s390x@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.42.tgz#06d40b957250ffd9a2183bfdfc9a03d6fd21b3e8"
-  integrity sha512-YFRhPCxl8nb//Wn6SiS5pmtplBi4z9yC2gLrYoYI/tvwuB1jldir9r7JwAGy1Ck4D7sE7wBN9GFtUUX/DLdcEQ==
+esbuild-linux-s390x@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.48.tgz#4b319eca2a5c64637fc7397ffbd9671719cdb6bf"
+  integrity sha512-tndw/0B9jiCL+KWKo0TSMaUm5UWBLsfCKVdbfMlb3d5LeV9WbijZ8Ordia8SAYv38VSJWOEt6eDCdOx8LqkC4g==
 
-esbuild-netbsd-64@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.42.tgz#185664f05f10914f14ed43bd9e22b7de584267f7"
-  integrity sha512-QYSD2k+oT9dqB/4eEM9c+7KyNYsIPgzYOSrmfNGDIyJrbT1d+CFVKvnKahDKNJLfOYj8N4MgyFaU9/Ytc6w5Vw==
+esbuild-netbsd-64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.48.tgz#c27cde8b5cb55dcc227943a18ab078fb98d0adbf"
+  integrity sha512-V9hgXfwf/T901Lr1wkOfoevtyNkrxmMcRHyticybBUHookznipMOHoF41Al68QBsqBxnITCEpjjd4yAos7z9Tw==
 
-esbuild-openbsd-64@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.42.tgz#c29006f659eb4e55283044bbbd4eb4054fae8839"
-  integrity sha512-M2meNVIKWsm2HMY7+TU9AxM7ZVwI9havdsw6m/6EzdXysyCFFSoaTQ/Jg03izjCsK17FsVRHqRe26Llj6x0MNA==
+esbuild-openbsd-64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.48.tgz#af5ab2d1cb41f09064bba9465fc8bf1309150df1"
+  integrity sha512-+IHf4JcbnnBl4T52egorXMatil/za0awqzg2Vy6FBgPcBpisDWT2sVz/tNdrK9kAqj+GZG/jZdrOkj7wsrNTKA==
 
-esbuild-sunos-64@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.42.tgz#aa9eec112cd1e7105e7bb37000eca7d460083f8f"
-  integrity sha512-uXV8TAZEw36DkgW8Ak3MpSJs1ofBb3Smkc/6pZ29sCAN1KzCAQzsje4sUwugf+FVicrHvlamCOlFZIXgct+iqQ==
+esbuild-sunos-64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.48.tgz#db3ae20526055cf6fd5c4582676233814603ac54"
+  integrity sha512-77m8bsr5wOpOWbGi9KSqDphcq6dFeJyun8TA+12JW/GAjyfTwVtOnN8DOt6DSPUfEV+ltVMNqtXUeTeMAxl5KA==
 
-esbuild-windows-32@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.42.tgz#c3fc450853c61a74dacc5679de301db23b73e61e"
-  integrity sha512-4iw/8qWmRICWi9ZOnJJf9sYt6wmtp3hsN4TdI5NqgjfOkBVMxNdM9Vt3626G1Rda9ya2Q0hjQRD9W1o+m6Lz6g==
+esbuild-windows-32@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.48.tgz#021ffceb0a3f83078262870da88a912293c57475"
+  integrity sha512-EPgRuTPP8vK9maxpTGDe5lSoIBHGKO/AuxDncg5O3NkrPeLNdvvK8oywB0zGaAZXxYWfNNSHskvvDgmfVTguhg==
 
-esbuild-windows-64@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.42.tgz#b877aa37ff47d9fcf0ccb1ca6a24b31475a5e555"
-  integrity sha512-j3cdK+Y3+a5H0wHKmLGTJcq0+/2mMBHPWkItR3vytp/aUGD/ua/t2BLdfBIzbNN9nLCRL9sywCRpOpFMx3CxzA==
+esbuild-windows-64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.48.tgz#a4d3407b580f9faac51f61eec095fa985fb3fee4"
+  integrity sha512-YmpXjdT1q0b8ictSdGwH3M8VCoqPpK1/UArze3X199w6u8hUx3V8BhAi1WjbsfDYRBanVVtduAhh2sirImtAvA==
 
-esbuild-windows-arm64@0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.42.tgz#79da8744626f24bc016dc40d016950b5a4a2bac5"
-  integrity sha512-+lRAARnF+hf8J0mN27ujO+VbhPbDqJ8rCcJKye4y7YZLV6C4n3pTRThAb388k/zqF5uM0lS5O201u0OqoWSicw==
+esbuild-windows-arm64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.48.tgz#762c0562127d8b09bfb70a3c816460742dd82880"
+  integrity sha512-HHaOMCsCXp0rz5BT2crTka6MPWVno121NKApsGs/OIW5QC0ggC69YMGs1aJct9/9FSUF4A1xNE/cLvgB5svR4g==
 
 esbuild@^0.14.27, esbuild@^0.14.42:
-  version "0.14.42"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.42.tgz#98587df0b024d5f6341b12a1d735a2bff55e1836"
-  integrity sha512-V0uPZotCEHokJdNqyozH6qsaQXqmZEOiZWrXnds/zaH/0SyrIayRXWRB98CENO73MIZ9T3HBIOsmds5twWtmgw==
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.48.tgz#da5d8d25cd2d940c45ea0cfecdca727f7aee2b85"
+  integrity sha512-w6N1Yn5MtqK2U1/WZTX9ZqUVb8IOLZkZ5AdHkT6x3cHDMVsYWC7WPdiLmx19w3i4Rwzy5LqsEMtVihG3e4rFzA==
   optionalDependencies:
-    esbuild-android-64 "0.14.42"
-    esbuild-android-arm64 "0.14.42"
-    esbuild-darwin-64 "0.14.42"
-    esbuild-darwin-arm64 "0.14.42"
-    esbuild-freebsd-64 "0.14.42"
-    esbuild-freebsd-arm64 "0.14.42"
-    esbuild-linux-32 "0.14.42"
-    esbuild-linux-64 "0.14.42"
-    esbuild-linux-arm "0.14.42"
-    esbuild-linux-arm64 "0.14.42"
-    esbuild-linux-mips64le "0.14.42"
-    esbuild-linux-ppc64le "0.14.42"
-    esbuild-linux-riscv64 "0.14.42"
-    esbuild-linux-s390x "0.14.42"
-    esbuild-netbsd-64 "0.14.42"
-    esbuild-openbsd-64 "0.14.42"
-    esbuild-sunos-64 "0.14.42"
-    esbuild-windows-32 "0.14.42"
-    esbuild-windows-64 "0.14.42"
-    esbuild-windows-arm64 "0.14.42"
+    esbuild-android-64 "0.14.48"
+    esbuild-android-arm64 "0.14.48"
+    esbuild-darwin-64 "0.14.48"
+    esbuild-darwin-arm64 "0.14.48"
+    esbuild-freebsd-64 "0.14.48"
+    esbuild-freebsd-arm64 "0.14.48"
+    esbuild-linux-32 "0.14.48"
+    esbuild-linux-64 "0.14.48"
+    esbuild-linux-arm "0.14.48"
+    esbuild-linux-arm64 "0.14.48"
+    esbuild-linux-mips64le "0.14.48"
+    esbuild-linux-ppc64le "0.14.48"
+    esbuild-linux-riscv64 "0.14.48"
+    esbuild-linux-s390x "0.14.48"
+    esbuild-netbsd-64 "0.14.48"
+    esbuild-openbsd-64 "0.14.48"
+    esbuild-sunos-64 "0.14.48"
+    esbuild-windows-32 "0.14.48"
+    esbuild-windows-64 "0.14.48"
+    esbuild-windows-arm64 "0.14.48"
 
 estree-walker@^2.0.2:
   version "2.0.2"
@@ -685,13 +685,13 @@ get-caller-file@^2.0.1:
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-intrinsic@^1.0.2:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
-  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.2.tgz#336975123e05ad0b7ba41f152ee4aadbea6cf598"
+  integrity sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==
   dependencies:
     function-bind "^1.1.1"
     has "^1.0.3"
-    has-symbols "^1.0.1"
+    has-symbols "^1.0.3"
 
 glob-parent@~5.1.2:
   version "5.1.2"
@@ -711,7 +711,7 @@ glob@^8.0.1:
     minimatch "^5.0.1"
     once "^1.3.0"
 
-has-symbols@^1.0.1, has-symbols@^1.0.2:
+has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
@@ -765,7 +765,7 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-core-module@^2.8.1:
+is-core-module@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
   integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
@@ -888,10 +888,10 @@ minimist@~1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
-moment@^2.10.2, moment@^2.29.2:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
-  integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==
+moment@^2.10.2, moment@^2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 nanoid@^3.3.4:
   version "3.3.4"
@@ -1129,7 +1129,7 @@ regenerator-runtime@^0.13.4:
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
-  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
 require-main-filename@^2.0.0:
   version "2.0.0"
@@ -1137,18 +1137,18 @@ require-main-filename@^2.0.0:
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
 resolve@^1.15.1, resolve@^1.22.0:
-  version "1.22.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
-  integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
   dependencies:
-    is-core-module "^2.8.1"
+    is-core-module "^2.9.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
 rollup@^2.59.0:
-  version "2.75.5"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.75.5.tgz#7985c1962483235dd07966f09fdad5c5f89f16d0"
-  integrity sha512-JzNlJZDison3o2mOxVmb44Oz7t74EfSd1SQrplQk0wSaXV7uLQXtVdHbxlcT3w+8tZ1TL4r/eLfc7nAbz38BBA==
+  version "2.76.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.76.0.tgz#c69fe03db530ac53fcb9523b3caa0d3c0b9491a1"
+  integrity sha512-9jwRIEY1jOzKLj3nsY/yot41r19ITdQrhs+q3ggNWhr9TQgduHqANvPpS32RNpzGklJu3G1AJfvlZLi/6wFgWA==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -1161,9 +1161,9 @@ sass-loader@^12.4.0:
     neo-async "^2.6.2"
 
 sass@^1.45.1:
-  version "1.52.2"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.52.2.tgz#cd1f03e0e7be5bb2cebcf1c34d735f087d790936"
-  integrity sha512-mfHB2VSeFS7sZlPv9YohB9GB7yWIgQNTGniQwfQ04EoQN0wsQEv7SwpCwy/x48Af+Z3vDeFXz+iuXM3HK/phZQ==
+  version "1.53.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.53.0.tgz#eab73a7baac045cc57ddc1d1ff501ad2659952eb"
+  integrity sha512-zb/oMirbKhUgRQ0/GFz8TSAwRq2IlR29vOUJZOx0l8sV+CkHUfHa4u5nqrG+1VceZp7Jfj59SVW9ogdhTvJDcQ==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
@@ -1179,12 +1179,12 @@ semver@^7.3.5:
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
-  integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+  integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
 simple-keyboard@^3.4.21:
-  version "3.4.109"
-  resolved "https://registry.yarnpkg.com/simple-keyboard/-/simple-keyboard-3.4.109.tgz#0eaac9a5ea9dd87fe5f107807a808af668fdadb1"
-  integrity sha512-PtqpdU7CH7oNzDfs226i/ViCm6r7d1OfC4ALP5LubnxQdRGv4xOyscUewQpx57/62q1zvgD2rQt6cO33532QOw==
+  version "3.4.122"
+  resolved "https://registry.yarnpkg.com/simple-keyboard/-/simple-keyboard-3.4.122.tgz#786b509b8d6ddd180472b3a0742ff4f8213b589b"
+  integrity sha512-qG1kXgkAMcJ/yBOjwRHbss/l5EaJoIgU0+4xXd/ynhdfPnD9juAAJNKfgFtFWu/GtfxFJy5N1H40DNI8HJJBEw==
 
 "source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2:
   version "1.0.2"
@@ -1235,7 +1235,7 @@ three@^0.141.0:
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
-  integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
+  integrity sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -1247,7 +1247,7 @@ to-regex-range@^5.0.1:
 token-stream@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/token-stream/-/token-stream-1.0.0.tgz#cc200eab2613f4166d27ff9afc7ca56d49df6eb4"
-  integrity sha1-zCAOqyYT9BZtJ/+a/HylbUnfbrQ=
+  integrity sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==
 
 tslib@^2.2.0:
   version "2.4.0"
@@ -1265,9 +1265,9 @@ upath@^2.0.1:
   integrity sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==
 
 vite@^2.5.2:
-  version "2.9.9"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.9.tgz#8b558987db5e60fedec2f4b003b73164cb081c5e"
-  integrity sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==
+  version "2.9.14"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.14.tgz#c438324c6594afd1050df3777da981dee988bb1b"
+  integrity sha512-P/UCjSpSMcE54r4mPak55hWAZPlyfS369svib/gpmz8/01L822lMPOJ/RYW6tLCe1RPvMvOsJ17erf55bKp4Hw==
   dependencies:
     esbuild "^0.14.27"
     postcss "^8.4.13"
@@ -1279,7 +1279,7 @@ vite@^2.5.2:
 void-elements@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
-  integrity sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=
+  integrity sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==
 
 vscode-css-languageservice@^5.1.9:
   version "5.4.2"
@@ -1427,11 +1427,11 @@ vue-qrcode@^1.0.0:
     vue-demi "^0.12.5"
 
 vue-router@4:
-  version "4.0.15"
-  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-4.0.15.tgz#b4a0661efe197f8c724e0f233308f8776e2c3667"
-  integrity sha512-xa+pIN9ZqORdIW1MkN2+d9Ui2pCM1b/UMgwYUCZOiFYHAvz/slKKBDha8DLrh5aCG/RibtrpyhKjKOZ85tYyWg==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-4.1.1.tgz#90cc533efafdcf90d157bdc20a376760cdb59c10"
+  integrity sha512-Wp1mEf2xCwT0ez7o9JvgpfBp9JGnVb+dPERzXDbugTatzJAJ60VWOhJKifQty85k+jOreoFHER4r5fu062PhPw==
   dependencies:
-    "@vue/devtools-api" "^6.0.0"
+    "@vue/devtools-api" "^6.1.4"
 
 vue-tsc@^0.31.4:
   version "0.31.4"
@@ -1460,7 +1460,7 @@ vuex@^3.6.2:
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
-  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+  integrity sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==
 
 with@^7.0.0:
   version "7.0.2"
@@ -1484,7 +1484,7 @@ wrap-ansi@^6.2.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 y18n@^4.0.0:
   version "4.0.3"

--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -137,7 +137,7 @@ func Status(writer http.ResponseWriter, request *http.Request) {
 	if err != nil {
 		return
 	}
-
+	fmt.Println("DETECTION")
 	marshal, err := json.Marshal(stats)
 	if err != nil {
 		return
@@ -156,8 +156,12 @@ func main() {
 
 	server.Addr = ":5050"
 	fmt.Println("Running on port :5050")
-	err := server.ListenAndServeTLS("./certs/monitor.crt", "./certs/monitor.key")
+	err := server.ListenAndServe()
 	if err != nil {
-		fmt.Println(err)
+		return
 	}
+	// err := server.ListenAndServeTLS("./certs/monitor.crt", "./certs/monitor.key")
+	// if err != nil {
+	// 	fmt.Println(err)
+	// }
 }

--- a/go.mod
+++ b/go.mod
@@ -52,12 +52,13 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/tadglines/go-pkgs v0.0.0-20140924210655-1f86682992f1 // indirect
+	github.com/tatsushid/go-fastping v0.0.0-20160109021039-d7bb493dee3e // indirect
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
 	github.com/tklauser/numcpus v0.4.0 // indirect
 	github.com/xiam/to v0.0.0-20191116183551-8328998fc0ed // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
-	golang.org/x/net v0.0.0-20220114011407-0dd24b26b47d // indirect
+	golang.org/x/net v0.0.0-20220708220712-1185a9018129 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -9,19 +9,21 @@ import (
 	"udap/internal/core/modules/device"
 	"udap/internal/core/modules/entity"
 	"udap/internal/core/modules/network"
+	"udap/internal/core/modules/notification"
 	"udap/internal/core/modules/user"
 	"udap/internal/core/modules/zone"
 )
 
 type Controller struct {
-	Attributes domain.AttributeService
-	Devices    domain.DeviceService
-	Entities   domain.EntityService
-	Networks   domain.NetworkService
-	Users      domain.UserService
-	Zones      domain.ZoneService
-	Endpoints  domain.EndpointService
-	Modules    domain.ModuleService
+	Attributes    domain.AttributeService
+	Devices       domain.DeviceService
+	Entities      domain.EntityService
+	Networks      domain.NetworkService
+	Notifications domain.NotificationService
+	Users         domain.UserService
+	Zones         domain.ZoneService
+	Endpoints     domain.EndpointService
+	Modules       domain.ModuleService
 }
 
 func NewController(db *gorm.DB) (*Controller, error) {
@@ -31,6 +33,7 @@ func NewController(db *gorm.DB) (*Controller, error) {
 	c.Devices = device.New(db)
 	c.Networks = network.New(db)
 	c.Users = user.New(db)
+	c.Notifications = notification.New(db)
 	c.Zones = zone.New(db)
 
 	return c, nil
@@ -69,6 +72,11 @@ func (c *Controller) WatchAll(resp chan domain.Mutation) {
 	}
 
 	err = c.Zones.Watch(resp)
+	if err != nil {
+		return
+	}
+
+	err = c.Notifications.Watch(resp)
 	if err != nil {
 		return
 	}
@@ -118,6 +126,11 @@ func (c *Controller) EmitAll() error {
 	}
 
 	err = c.Devices.EmitAll()
+	if err != nil {
+		return err
+	}
+
+	err = c.Notifications.EmitAll()
 	if err != nil {
 		return err
 	}

--- a/internal/core/domain/device.go
+++ b/internal/core/domain/device.go
@@ -2,17 +2,23 @@
 
 package domain
 
-import "udap/internal/core/domain/common"
+import (
+	"time"
+	"udap/internal/core/domain/common"
+)
 
 type Device struct {
 	common.Persistent
-	NetworkId string `json:"networkId" gorm:"-"`
-	EntityId  string `json:"entityId" gorm:"-"`
-	Name      string `json:"name"`
-	Hostname  string `json:"hostname"`
-	Mac       string `json:"mac"`
-	Ipv4      string `json:"ipv4"`
-	Ipv6      string `json:"ipv6"`
+	LastSeen  time.Time     `json:"lastSeen"`
+	Latency   time.Duration `json:"latency"`
+	State     string        `json:"state"`
+	NetworkId string        `json:"networkId" gorm:"-"`
+	EntityId  string        `json:"entityId" gorm:"-"`
+	Name      string        `json:"name"`
+	Hostname  string        `json:"hostname"`
+	Mac       string        `json:"mac"`
+	Ipv4      string        `json:"ipv4"`
+	Ipv6      string        `json:"ipv6"`
 }
 
 type DeviceRepository interface {

--- a/internal/core/domain/device.go
+++ b/internal/core/domain/device.go
@@ -7,18 +7,40 @@ import (
 	"udap/internal/core/domain/common"
 )
 
+type Utilization struct {
+	Memory struct {
+		Total uint64  `json:"total"`
+		Used  float64 `json:"used"`
+	} `json:"memory"`
+	Network struct {
+		Hostname string `json:"hostname"`
+		Ipv4     string `json:"ipv4"`
+		Mac      string `json:"mac"`
+	} `json:"network"`
+	Cpu struct {
+		Cores int       `json:"cores"`
+		Usage []float64 `json:"usage"`
+	} `json:"cpu"`
+	Disk struct {
+		Total uint64  `json:"total"`
+		Used  float64 `json:"used"`
+	} `json:"disk"`
+}
+
 type Device struct {
 	common.Persistent
-	LastSeen  time.Time     `json:"lastSeen"`
-	Latency   time.Duration `json:"latency"`
-	State     string        `json:"state"`
-	NetworkId string        `json:"networkId" gorm:"-"`
-	EntityId  string        `json:"entityId" gorm:"-"`
-	Name      string        `json:"name"`
-	Hostname  string        `json:"hostname"`
-	Mac       string        `json:"mac"`
-	Ipv4      string        `json:"ipv4"`
-	Ipv6      string        `json:"ipv6"`
+	LastSeen    time.Time     `json:"lastSeen"`
+	Latency     time.Duration `json:"latency"`
+	State       string        `json:"state"`
+	NetworkId   string        `json:"networkId" gorm:"-"`
+	EntityId    string        `json:"entityId" gorm:"-"`
+	Name        string        `json:"name"`
+	Hostname    string        `json:"hostname"`
+	IsQueryable bool          `json:"isQueryable" gorm:"default:false"`
+	Utilization Utilization   `json:"utilization" gorm:"-"`
+	Mac         string        `json:"mac"`
+	Ipv4        string        `json:"ipv4"`
+	Ipv6        string        `json:"ipv6"`
 }
 
 type DeviceRepository interface {

--- a/internal/core/domain/endpoint.go
+++ b/internal/core/domain/endpoint.go
@@ -49,6 +49,7 @@ type EndpointOperator interface {
 	Unenroll(id string) error
 	Send(id string, operation string, payload any) error
 	SendAll(id string, operation string, payload any) error
+	CloseAll() error
 }
 
 type EndpointService interface {
@@ -56,7 +57,7 @@ type EndpointService interface {
 	FindById(id string) (*Endpoint, error)
 	FindByKey(key string) (*Endpoint, error)
 	Create(*Endpoint) error
-
+	CloseAll() error
 	Observable
 
 	Enroll(id string, conn *websocket.Conn) error

--- a/internal/core/domain/module.go
+++ b/internal/core/domain/module.go
@@ -42,6 +42,7 @@ type ModuleService interface {
 	Dispose(module *Module) error
 	UpdateAll() error
 	RunAll() error
+	DisposeAll() error
 	LoadAll() error
 	BuildAll() error
 	FindAll() (*[]Module, error)

--- a/internal/core/domain/module.go
+++ b/internal/core/domain/module.go
@@ -14,6 +14,7 @@ type Module struct {
 	Author      string      `json:"author"`
 	Channel     chan Module `json:"-" gorm:"-"`
 	State       string      `json:"state"`
+	Running     bool        `json:"running" gorm:"default:false"`
 	Enabled     bool        `json:"enabled" gorm:"default:true"`
 	Recover     int         `json:"recover"`
 }

--- a/internal/core/domain/module.go
+++ b/internal/core/domain/module.go
@@ -28,6 +28,7 @@ type ModuleOperator interface {
 	Load(module *Module) error
 	Update(module *Module) error
 	Run(module *Module) error
+	Dispose(module *Module) error
 }
 
 type ModuleService interface {
@@ -37,6 +38,7 @@ type ModuleService interface {
 	Load(module *Module) error
 	Update(module *Module) error
 	Run(module *Module) error
+	Dispose(module *Module) error
 	UpdateAll() error
 	RunAll() error
 	LoadAll() error

--- a/internal/core/domain/notification.go
+++ b/internal/core/domain/notification.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 Braden Nicholson
+
+package domain
+
+import "udap/internal/core/domain/common"
+
+type Notification struct {
+	common.Persistent
+	Title    string `json:"title"`
+	Target   string `json:"string"`
+	Module   string `json:"module"`
+	Body     string `json:"body"`
+	Priority int    `json:"priority"`
+}
+
+type NotificationRepository interface {
+	common.Persist[Notification]
+}
+
+type NotificationOperator interface {
+	Send(notification Notification) error
+}
+
+type NotificationService interface {
+	Observable
+	FindAll() (*[]Notification, error)
+	FindById(id string) (*Notification, error)
+	Create(*Notification) error
+	FindOrCreate(*Notification) error
+	Register(*Notification) error
+	Update(*Notification) error
+	Delete(*Notification) error
+}

--- a/internal/core/generic/store.go
+++ b/internal/core/generic/store.go
@@ -9,7 +9,7 @@ import (
 
 type persistent interface {
 	domain.User | domain.Module | domain.Entity | domain.Device | domain.Attribute | domain.Endpoint | domain.
-		Network | domain.Zone | Mock
+		Network | domain.Zone | domain.Notification | Mock
 }
 
 type Store[T persistent] struct {

--- a/internal/core/migrate.go
+++ b/internal/core/migrate.go
@@ -9,7 +9,7 @@ import (
 
 func MigrateModels(db *gorm.DB) error {
 	err := db.AutoMigrate(domain.Attribute{}, domain.Entity{}, domain.Module{}, domain.Device{}, domain.Endpoint{},
-		domain.User{}, domain.Network{}, domain.Zone{})
+		domain.User{}, domain.Network{}, domain.Zone{}, domain.Notification{})
 	if err != nil {
 		return err
 	}

--- a/internal/core/modules/device/repository.go
+++ b/internal/core/modules/device/repository.go
@@ -19,3 +19,7 @@ func NewRepository(db *gorm.DB) domain.DeviceRepository {
 		Store: generic.NewStore[domain.Device](db),
 	}
 }
+
+func (m *deviceRepo) FindOrCreate(device *domain.Device) error {
+	return m.db.FirstOrCreate(device, "mac = ?", device.Mac).Error
+}

--- a/internal/core/modules/device/service.go
+++ b/internal/core/modules/device/service.go
@@ -49,6 +49,14 @@ func (u *deviceService) Watch(mut chan<- domain.Mutation) error {
 }
 
 func (u deviceService) Register(device *domain.Device) error {
+	err := u.repository.FindOrCreate(device)
+	if err != nil {
+		return err
+	}
+	err = u.emit(device)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -75,7 +83,18 @@ func (u deviceService) FindOrCreate(device *domain.Device) error {
 }
 
 func (u deviceService) Update(device *domain.Device) error {
-	return u.repository.Update(device)
+
+	err := u.repository.Update(device)
+	if err != nil {
+		return err
+	}
+
+	err = u.emit(device)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (u deviceService) Delete(device *domain.Device) error {

--- a/internal/core/modules/endpoint/service.go
+++ b/internal/core/modules/endpoint/service.go
@@ -57,6 +57,10 @@ func (u *endpointService) Watch(ref chan<- domain.Mutation) error {
 	return nil
 }
 
+func (u endpointService) CloseAll() error {
+	return u.operator.CloseAll()
+}
+
 func (u endpointService) Send(id string, operation string, payload any) error {
 	err := u.operator.Send(id, operation, payload)
 	if err != nil {

--- a/internal/core/modules/module/operator.go
+++ b/internal/core/modules/module/operator.go
@@ -112,11 +112,11 @@ func (m *moduleOperator) Load(module *domain.Module) error {
 func (m *moduleOperator) Run(module *domain.Module) error {
 	// Check to make sure the module is enabled
 	if !module.Enabled {
-		return fmt.Errorf("module is not enabled")
+		return fmt.Errorf("module '%s' is not enabled; cannot run", module.Name)
 	}
 	// Make sure the module is not already running
 	if module.Running {
-		return fmt.Errorf("module is already running")
+		return fmt.Errorf("module '%s' is already running; cannot run again", module.Name)
 	}
 	// Get the local module
 	local, err := m.getModule(module)
@@ -136,11 +136,11 @@ func (m *moduleOperator) Run(module *domain.Module) error {
 func (m *moduleOperator) Update(module *domain.Module) error {
 	// Check to make sure the module is enabled
 	if !module.Enabled {
-		return fmt.Errorf("module is not enabled")
+		return fmt.Errorf("module '%s' is not enabled; cannot update", module.Name)
 	}
 	// Make sure the module is running
-	if module.Running {
-		return fmt.Errorf("module is not running")
+	if !module.Running {
+		return fmt.Errorf("module '%s' is not running; cannot update", module.Name)
 	}
 	// Get the local module
 	local, err := m.getModule(module)
@@ -164,11 +164,11 @@ func (m *moduleOperator) Update(module *domain.Module) error {
 func (m *moduleOperator) Dispose(module *domain.Module) error {
 	// Check to make sure the module is enabled
 	if !module.Enabled {
-		return fmt.Errorf("module is not enabled")
+		return fmt.Errorf("module '%s' is not enabled; cannot dispose", module.Name)
 	}
 	// Make sure the module is running
 	if !module.Running {
-		return fmt.Errorf("module is not running")
+		return fmt.Errorf("module '%s' is not running; cannot dispose", module.Name)
 	}
 	// Get the local module
 	local, err := m.getModule(module)
@@ -180,6 +180,6 @@ func (m *moduleOperator) Dispose(module *domain.Module) error {
 	if err != nil {
 		return err
 	}
-
+	log.Event("Module '%s' unloaded.", module.Name)
 	return nil
 }

--- a/internal/core/modules/module/operator.go
+++ b/internal/core/modules/module/operator.go
@@ -41,55 +41,7 @@ func (m *moduleOperator) setModule(module *domain.Module, moduleInterface plugin
 	return nil
 }
 
-func (m *moduleOperator) Update(module *domain.Module) error {
-	if module.Enabled {
-		local, err := m.getModule(module)
-		if err != nil {
-			return err
-		}
-		pulse.Begin(module.Id)
-		err = local.Update()
-		if err != nil {
-			return err
-		}
-		pulse.End(module.Id)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (m *moduleOperator) Run(module *domain.Module) error {
-	if module.Enabled {
-		local, err := m.getModule(module)
-		if err != nil {
-			return err
-		}
-		err = local.Run()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (m *moduleOperator) Dispose(module *domain.Module) error {
-	if module.Enabled {
-		local, err := m.getModule(module)
-		if err != nil {
-			return err
-		}
-		err = local.Dispose()
-		if err != nil {
-			return err
-		}
-	} else {
-		return fmt.Errorf("module is not enabled")
-	}
-	return nil
-}
-
+// Build will compile a valid plugin file into a readable binary
 func (m *moduleOperator) Build(module *domain.Module) error {
 	start := time.Now()
 	if _, err := os.Stat(module.Path); err != nil {
@@ -99,6 +51,7 @@ func (m *moduleOperator) Build(module *domain.Module) error {
 	timeout, cancelFunc := context.WithTimeout(context.Background(), time.Second*15)
 	// Cancel the timeout of it exits before the timeout is up
 	defer cancelFunc()
+	// Create the binary file path
 	binary := strings.Replace(module.Path, ".go", ".so", 1)
 	// Prepare the command arguments
 	args := []string{"build", "-v", "-buildmode=plugin", "-o", binary, module.Path}
@@ -114,34 +67,119 @@ func (m *moduleOperator) Build(module *domain.Module) error {
 	return nil
 }
 
+// Load is used to find a pre-built plugin file, and load it into the local system.
+// The module reference should be saved to the repository after loading.
 func (m *moduleOperator) Load(module *domain.Module) error {
+	// Create the binary file path
 	binary := strings.Replace(module.Path, ".go", ".so", 1)
+	// Attempt to load the plugin binary
 	p, err := plugin.Load(binary)
 	if err != nil {
 		return err
 	}
+	// Extract the plugin interface
 	mod := p.(plugin.ModuleInterface)
 	if mod == nil {
 		return fmt.Errorf("cannot read module")
 	}
+	// Connect the module to the UDAP runtime
 	err = mod.Connect(m.ctrl)
 	if err != nil {
 		return err
 	}
+	// Run the setup method
 	setup, err := mod.Setup()
 	if err != nil {
 		return err
 	}
-
+	// Update the module parameters
 	module.Name = setup.Name
 	module.Type = setup.Type
 	module.Version = setup.Version
 	module.Author = setup.Author
 	module.Description = setup.Description
+	// Emplace the module into the local buffer
 	err = m.setModule(module, mod)
 	if err != nil {
 		return err
 	}
+	// Log the status
 	log.Event("Module '%s' loaded.", module.Name)
+	return nil
+}
+
+// Run attempts to initialize the plugin's runtime
+func (m *moduleOperator) Run(module *domain.Module) error {
+	// Check to make sure the module is enabled
+	if !module.Enabled {
+		return fmt.Errorf("module is not enabled")
+	}
+	// Make sure the module is not already running
+	if module.Running {
+		return fmt.Errorf("module is already running")
+	}
+	// Get the local module
+	local, err := m.getModule(module)
+	if err != nil {
+		return err
+	}
+	// Run the local module
+	err = local.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Update is called on every tick, it is the plugin's decision whether to use the time or defer.
+func (m *moduleOperator) Update(module *domain.Module) error {
+	// Check to make sure the module is enabled
+	if !module.Enabled {
+		return fmt.Errorf("module is not enabled")
+	}
+	// Make sure the module is running
+	if module.Running {
+		return fmt.Errorf("module is not running")
+	}
+	// Get the local module
+	local, err := m.getModule(module)
+	if err != nil {
+		return err
+	}
+	// Begin the lifecycle metrics
+	pulse.Begin(module.Id)
+	// Run the update
+	err = local.Update()
+	if err != nil {
+		return err
+	}
+	// End the pulse metric
+	pulse.End(module.Id)
+
+	return nil
+}
+
+// Dispose is called at the end of the lifecycle, it attempts to halt activity.
+func (m *moduleOperator) Dispose(module *domain.Module) error {
+	// Check to make sure the module is enabled
+	if !module.Enabled {
+		return fmt.Errorf("module is not enabled")
+	}
+	// Make sure the module is running
+	if !module.Running {
+		return fmt.Errorf("module is not running")
+	}
+	// Get the local module
+	local, err := m.getModule(module)
+	if err != nil {
+		return err
+	}
+	// Dispose of the local module
+	err = local.Dispose()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/internal/core/modules/module/operator.go
+++ b/internal/core/modules/module/operator.go
@@ -74,6 +74,22 @@ func (m *moduleOperator) Run(module *domain.Module) error {
 	return nil
 }
 
+func (m *moduleOperator) Dispose(module *domain.Module) error {
+	if module.Enabled {
+		local, err := m.getModule(module)
+		if err != nil {
+			return err
+		}
+		err = local.Dispose()
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("module is not enabled")
+	}
+	return nil
+}
+
 func (m *moduleOperator) Build(module *domain.Module) error {
 	start := time.Now()
 	if _, err := os.Stat(module.Path); err != nil {

--- a/internal/core/modules/module/service.go
+++ b/internal/core/modules/module/service.go
@@ -86,6 +86,8 @@ func (u *moduleService) Run(module *domain.Module) error {
 		}
 		return err
 	}
+	// Set the module as running so it can begin updating
+	module.Running = false
 	// Mark the module as running
 	err = u.setState(module, RUNNING)
 	if err != nil {
@@ -95,15 +97,13 @@ func (u *moduleService) Run(module *domain.Module) error {
 }
 
 func (u *moduleService) Load(module *domain.Module) error {
+	// Attempt to load the module
 	err := u.operator.Load(module)
 	if err != nil {
 		return err
 	}
+	// Set the state if the operation was a success, setState will also update the module data
 	err = u.setState(module, IDLE)
-	if err != nil {
-		return err
-	}
-	err = u.repository.Update(module)
 	if err != nil {
 		return err
 	}
@@ -126,6 +126,8 @@ func (u *moduleService) Dispose(module *domain.Module) error {
 	if err != nil {
 		return err
 	}
+	// Set the module as not running, so it is not updated
+	module.Running = false
 	// Mark the module as stopped if the disposal was successful
 	err = u.setState(module, STOPPED)
 	if err != nil {

--- a/internal/core/modules/module/service.go
+++ b/internal/core/modules/module/service.go
@@ -19,6 +19,17 @@ type moduleService struct {
 	channel    chan<- domain.Mutation
 }
 
+const (
+	DISCOVERED    = "discovered"
+	UNINITIALIZED = "uninitialized"
+	IDLE          = "idle"
+	STARTING      = "starting"
+	RUNNING       = "running"
+	HALTING       = "halting"
+	STOPPED       = "stopped"
+	ERROR         = "error"
+)
+
 func (u *moduleService) Watch(ref chan<- domain.Mutation) error {
 	if u.channel != nil {
 		return fmt.Errorf("channel in use")
@@ -58,12 +69,37 @@ func (u *moduleService) Update(module *domain.Module) error {
 	return u.operator.Update(module)
 }
 
+// Run runs the startup code for each module, not to be confused with the setup function with connects and the module
 func (u *moduleService) Run(module *domain.Module) error {
-	return u.operator.Run(module)
+	// Mark the module start as starting
+	err := u.setState(module, STARTING)
+	if err != nil {
+		return err
+	}
+	// Attempt to run the module
+	err = u.operator.Run(module)
+	if err != nil {
+		// Set the module state to error if the run fails
+		err = u.setState(module, ERROR)
+		if err != nil {
+			return err
+		}
+		return err
+	}
+	// Mark the module as running
+	err = u.setState(module, RUNNING)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (u *moduleService) Load(module *domain.Module) error {
 	err := u.operator.Load(module)
+	if err != nil {
+		return err
+	}
+	err = u.setState(module, IDLE)
 	if err != nil {
 		return err
 	}
@@ -76,6 +112,26 @@ func (u *moduleService) Load(module *domain.Module) error {
 
 func (u *moduleService) Build(module *domain.Module) error {
 	return u.operator.Build(module)
+}
+
+// Dispose halts a modules activity and destroys its runtime
+func (u *moduleService) Dispose(module *domain.Module) error {
+	// Mark the state as halting, since it may take a while
+	err := u.setState(module, HALTING)
+	if err != nil {
+		return err
+	}
+	// Attempt to dispose of the module (only works if the module developer plays nicely)
+	err = u.operator.Dispose(module)
+	if err != nil {
+		return err
+	}
+	// Mark the module as stopped if the disposal was successful
+	err = u.setState(module, STOPPED)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (u *moduleService) UpdateAll() error {
@@ -99,18 +155,13 @@ func (u *moduleService) UpdateAll() error {
 	return nil
 }
 
-const (
-	DISCOVERED    = "discovered"
-	UNINITIALIZED = "uninitialized"
-	IDLE          = "idle"
-	RUNNING       = "running"
-	STOPPED       = "stopped"
-	ERROR         = "error"
-)
-
 func (u *moduleService) setState(module *domain.Module, state string) error {
 	module.State = state
 	err := u.repository.Update(module)
+	if err != nil {
+		return err
+	}
+	err = u.emit(module)
 	if err != nil {
 		return err
 	}
@@ -124,19 +175,11 @@ func (u *moduleService) RunAll() error {
 	}
 
 	for _, module := range *modules {
-		err = u.setState(&module, RUNNING)
-		if err != nil {
-			return err
-		}
-
 		go func(mod domain.Module) {
 			err = u.Run(&mod)
 			if err != nil {
 				log.Err(err)
-				err = u.setState(&mod, ERROR)
-				if err != nil {
-					return
-				}
+				return
 			}
 		}(module)
 	}
@@ -157,10 +200,6 @@ func (u *moduleService) LoadAll() error {
 			err = u.Load(&mod)
 			if err != nil {
 				log.Err(err)
-				return
-			}
-			err = u.setState(&mod, IDLE)
-			if err != nil {
 				return
 			}
 		}(module)
@@ -293,6 +332,13 @@ func (u moduleService) Reload(name string) error {
 }
 
 func (u moduleService) Halt(name string) error {
-	// TODO implement me
-	panic("implement me")
+	byName, err := u.FindByName(name)
+	if err != nil {
+		return err
+	}
+	err = u.Dispose(byName)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/core/modules/notification/notification.go
+++ b/internal/core/modules/notification/notification.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2022 Braden Nicholson
+
+package notification
+
+import (
+	"gorm.io/gorm"
+	"udap/internal/core/domain"
+)
+
+func New(db *gorm.DB) domain.NotificationService {
+	repo := NewRepository(db)
+	service := NewService(repo)
+	return service
+}

--- a/internal/core/modules/notification/operator.go
+++ b/internal/core/modules/notification/operator.go
@@ -3,24 +3,17 @@
 package notification
 
 import (
-	"udap/internal/controller"
 	"udap/internal/core/domain"
 )
 
 type notificationOperator struct {
-	ctrl *controller.Controller
 }
 
-func NewOperator(ctrl *controller.Controller) domain.NotificationOperator {
-	return &notificationOperator{
-		ctrl: ctrl,
-	}
+func NewOperator() domain.NotificationOperator {
+	return &notificationOperator{}
 }
 
 func (m *notificationOperator) Send(notification domain.Notification) error {
-	err := m.ctrl.Notifications.Create(&notification)
-	if err != nil {
-		return err
-	}
+
 	return nil
 }

--- a/internal/core/modules/notification/operator.go
+++ b/internal/core/modules/notification/operator.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 Braden Nicholson
+
+package notification
+
+import (
+	"udap/internal/controller"
+	"udap/internal/core/domain"
+)
+
+type notificationOperator struct {
+	ctrl *controller.Controller
+}
+
+func NewOperator(ctrl *controller.Controller) domain.NotificationOperator {
+	return &notificationOperator{
+		ctrl: ctrl,
+	}
+}
+
+func (m *notificationOperator) Send(notification domain.Notification) error {
+	err := m.ctrl.Notifications.Create(&notification)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/core/modules/notification/repository.go
+++ b/internal/core/modules/notification/repository.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2022 Braden Nicholson
+
+package notification
+
+import (
+	"gorm.io/gorm"
+	"udap/internal/core/domain"
+	"udap/internal/core/generic"
+)
+
+type notificationRepo struct {
+	generic.Store[domain.Notification]
+	db *gorm.DB
+}
+
+func NewRepository(db *gorm.DB) domain.NotificationRepository {
+	return &notificationRepo{
+		db:    db,
+		Store: generic.NewStore[domain.Notification](db),
+	}
+}

--- a/internal/core/modules/notification/service.go
+++ b/internal/core/modules/notification/service.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2022 Braden Nicholson
+
+package notification
+
+import (
+	"fmt"
+	"udap/internal/core/domain"
+)
+
+type notificationService struct {
+	repository domain.NotificationRepository
+	channel    chan<- domain.Mutation
+}
+
+func (u *notificationService) EmitAll() error {
+	all, err := u.FindAll()
+	if err != nil {
+		return err
+	}
+	for _, notification := range *all {
+		err = u.emit(&notification)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (u *notificationService) emit(notification *domain.Notification) error {
+	if u.channel == nil {
+		return nil
+	}
+	u.channel <- domain.Mutation{
+		Status:    "update",
+		Operation: "notification",
+		Body:      *notification,
+		Id:        notification.Id,
+	}
+	return nil
+}
+
+func (u *notificationService) Watch(mut chan<- domain.Mutation) error {
+	if u.channel != nil {
+		return fmt.Errorf("channel already set")
+	}
+	u.channel = mut
+	return nil
+}
+
+func (u notificationService) Register(notification *domain.Notification) error {
+	return nil
+}
+
+func NewService(repository domain.NotificationRepository) domain.NotificationService {
+	return &notificationService{repository: repository}
+}
+
+// Repository Mapping
+
+func (u notificationService) FindAll() (*[]domain.Notification, error) {
+	return u.repository.FindAll()
+}
+
+func (u notificationService) FindById(id string) (*domain.Notification, error) {
+	return u.repository.FindById(id)
+}
+
+func (u notificationService) Create(notification *domain.Notification) error {
+	return u.repository.Create(notification)
+}
+
+func (u notificationService) FindOrCreate(notification *domain.Notification) error {
+	return u.repository.FindOrCreate(notification)
+}
+
+func (u notificationService) Update(notification *domain.Notification) error {
+	return u.repository.Update(notification)
+}
+
+func (u notificationService) Delete(notification *domain.Notification) error {
+	return u.repository.Delete(notification)
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -55,6 +55,8 @@ const (
 	process
 	event
 	critical
+	tick
+	rec
 )
 
 func log(logType LogType, format string, args ...interface{}) {
@@ -69,7 +71,15 @@ func log(logType LogType, format string, args ...interface{}) {
 		ln = false
 		break
 	case event:
-		prefix = fmt.Sprintf("%s[EVENT]%s", Reset+BoldGreen, Reset+Faint)
+		prefix = fmt.Sprintf("%s[EVENT]%s", Reset+BoldGreen, Reset)
+		ln = true
+		break
+	case tick:
+		prefix = fmt.Sprintf("%s[TICK]%s", Reset+BoldBlue, Reset)
+		ln = true
+		break
+	case rec:
+		prefix = fmt.Sprintf("%s[SAFE]%s", Reset+BoldMagenta, Reset)
 		ln = true
 		break
 	case critical:
@@ -115,6 +125,14 @@ func Critical(format string, args ...interface{}) {
 
 func Log(format string, args ...interface{}) {
 	log(module, format, args...)
+}
+
+func Tick(format string, args ...interface{}) {
+	log(tick, format, args...)
+}
+
+func Recovered(format string, args ...interface{}) {
+	log(rec, format, args...)
 }
 
 func Event(format string, args ...interface{}) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -181,6 +181,7 @@ func (o *orchestrator) Run() error {
 	routes.NewUserRouter(o.controller.Users).RouteUsers(o.router)
 	routes.NewAttributeRouter(o.controller.Attributes).RouteAttributes(o.router)
 	routes.NewZoneRouter(o.controller.Zones).RouteZones(o.router)
+	routes.NewDeviceRouter(o.controller.Devices).RouteDevices(o.router)
 	routes.NewEndpointRouter(o.endpoints).RouteEndpoints(o.router)
 	routes.NewModuleRouter(o.modules).RouteModules(o.router)
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -77,6 +77,7 @@ func (o *orchestrator) Start() error {
 		for range c {
 			_ = o.server.Close()
 			o.done <- true
+			return
 		}
 	}()
 
@@ -155,7 +156,7 @@ func (o *orchestrator) tick() <-chan error {
 		}
 		delta := time.Since(start)
 		if delta < o.maxTick && o.maxTick-delta > 250*time.Millisecond {
-			log.Event("Elapsed: %s", delta.String())
+			log.Tick("Elapsed: %s", delta.String())
 			time.Sleep(o.maxTick - delta - time.Millisecond*250)
 		}
 		out <- nil

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
-	"runtime/pprof"
 	"sync"
 	"time"
 	"udap/internal/controller"
@@ -32,9 +31,9 @@ type orchestrator struct {
 	server     *http.Server
 	maxTick    time.Duration
 	controller *controller.Controller
-
-	modules   domain.ModuleService
-	endpoints domain.EndpointService
+	done       chan bool
+	modules    domain.ModuleService
+	endpoints  domain.EndpointService
 
 	mutations chan domain.Mutation
 }
@@ -45,7 +44,10 @@ type Orchestrator interface {
 }
 
 func (o *orchestrator) Terminate(reason string) {
-
+	_ = o.modules.DisposeAll()
+	_ = o.endpoints.CloseAll()
+	fmt.Printf("\nThreads at exit: %d\n", runtime.NumGoroutine())
+	os.Exit(0)
 }
 
 func NewOrchestrator() (Orchestrator, error) {
@@ -60,6 +62,7 @@ func NewOrchestrator() (Orchestrator, error) {
 	return &orchestrator{
 		db:         db,
 		router:     r,
+		done:       make(chan bool),
 		controller: nil,
 		maxTick:    time.Second,
 		mutations:  make(chan domain.Mutation, 16),
@@ -73,8 +76,7 @@ func (o *orchestrator) Start() error {
 	go func() {
 		for range c {
 			_ = o.server.Close()
-			fmt.Printf("\nThreads at exit: %d\n", runtime.NumGoroutine())
-			os.Exit(0)
+			o.done <- true
 		}
 	}()
 
@@ -186,14 +188,12 @@ func (o *orchestrator) Run() error {
 	routes.NewModuleRouter(o.modules).RouteModules(o.router)
 
 	runtimes.NewModuleRuntime(o.modules)
+
 	go func() {
 		defer wg.Done()
 		err := o.runServer()
 		if err != nil {
 			log.Err(err)
-			pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
-			fmt.Printf("\nThreads @ exit: %d\n", runtime.NumGoroutine())
-			os.Exit(1)
 			return
 		}
 	}()
@@ -203,6 +203,11 @@ func (o *orchestrator) Run() error {
 		for {
 			pulse.Begin("update")
 			select {
+			case <-o.done:
+				log.Event("Event loop exiting...")
+				o.Terminate("Terminated")
+				close(o.mutations)
+				return
 			case <-time.After(o.maxTick + time.Millisecond*100):
 				log.Event("Orchestrator event loop timed out")
 				continue

--- a/internal/plugin/default.go
+++ b/internal/plugin/default.go
@@ -44,3 +44,9 @@ func (m *Module) Connect(ctrl *controller.Controller) error {
 	m.Controller = ctrl
 	return nil
 }
+
+// Dispose is called once at the launch of the module
+func (m *Module) Dispose() error {
+
+	return nil
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -18,6 +18,8 @@ type ModuleInterface interface {
 	Run() error
 	// Update is used to assign channels
 	Update() error
+	// Dispose provides module-relevant data
+	Dispose() error
 }
 
 // Load attempts to load the plugin from a given path

--- a/internal/port/routes/device.go
+++ b/internal/port/routes/device.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2022 Braden Nicholson
+
+package routes
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/go-chi/chi"
+	"net/http"
+	"udap/internal/core/domain"
+)
+
+type DeviceRouter interface {
+	RouteDevices(router chi.Router)
+}
+
+type deviceRouter struct {
+	service domain.DeviceService
+}
+
+func NewDeviceRouter(service domain.DeviceService) DeviceRouter {
+	return deviceRouter{
+		service: service,
+	}
+}
+
+func (r deviceRouter) RouteDevices(router chi.Router) {
+	router.Route("/devices", func(local chi.Router) {
+		local.Post("/update", r.update)
+	})
+}
+
+func (r deviceRouter) update(w http.ResponseWriter, req *http.Request) {
+
+	var buf bytes.Buffer
+
+	_, err := buf.ReadFrom(req.Body)
+	if err != nil {
+		http.Error(w, "could not parse device", 400)
+		return
+	}
+
+	ref := domain.Device{}
+	err = json.Unmarshal(buf.Bytes(), &ref)
+	if err != nil {
+		http.Error(w, "could not parse device", 400)
+		return
+	}
+
+	err = r.service.Update(&ref)
+	if err != nil {
+		http.Error(w, "could not find device", 400)
+		return
+	}
+
+	w.WriteHeader(200)
+}

--- a/internal/port/runtimes/module.go
+++ b/internal/port/runtimes/module.go
@@ -18,7 +18,6 @@ func NewModuleRuntime(service domain.ModuleService) {
 		log.Err(err)
 		return
 	}
-
 	err = service.LoadAll()
 	if err != nil {
 		return

--- a/modules/govee/govee.go
+++ b/modules/govee/govee.go
@@ -114,7 +114,7 @@ func (g *Govee) sendApiRequest(method string, path string, body json.RawMessage)
 	var buf bytes.Buffer
 	buf.Write(body)
 	c := http.Client{}
-
+	c.Timeout = time.Millisecond * 400
 	p := fmt.Sprintf("https://developer-api.govee.com/v1/devices%s", path)
 	request, err := http.NewRequest(method, p, &buf)
 	if err != nil {

--- a/modules/govee/govee.go
+++ b/modules/govee/govee.go
@@ -98,9 +98,16 @@ func (g *Govee) fetchDevices() ([]Device, error) {
 	if err != nil {
 		return nil, err
 	}
+	//
+	// fmt.Println(d)
 
 	return d.Devices, nil
 }
+
+// a5:20:d4:ad:fc:08:b0:b3 H6003 Entrance
+// 98:34:d4:ad:fc:0a:3f:2d H6003 Workstation
+// 3d:b2:d4:ad:fc:09:38:0f H6003 Kitchen
+// 6d:2f:d4:ad:fc:09:3f:25 H6003 Nightstand
 
 func (g *Govee) sendApiRequest(method string, path string, body json.RawMessage) (json.RawMessage, error) {
 

--- a/modules/homekit/homekit.go
+++ b/modules/homekit/homekit.go
@@ -19,9 +19,10 @@ var Module Homekit
 
 type Homekit struct {
 	plugin.Module
-	bridge  *accessory.Bridge
-	config  hc.Config
-	devices map[string]*service.Service
+	bridge    *accessory.Bridge
+	transport hc.Transport
+	config    hc.Config
+	devices   map[string]*service.Service
 }
 
 func init() {
@@ -61,10 +62,7 @@ func (h *Homekit) Update() error {
 	return nil
 }
 
-func (h *Homekit) Run() error {
-
-	time.Sleep(time.Second * 5)
-
+func (h *Homekit) Host() {
 	var accessories []*accessory.Accessory
 
 	entities, err := h.Entities.FindAll()
@@ -86,7 +84,7 @@ func (h *Homekit) Run() error {
 
 			err = device.syncAttributes(h.Attributes, entity.Id)
 			if err != nil {
-				return err
+				return
 			}
 
 			accessories = append(accessories, device.Accessory)
@@ -109,18 +107,32 @@ func (h *Homekit) Run() error {
 
 	}
 
-	t, err := hc.NewIPTransport(h.config, h.bridge.Accessory, accessories...)
+	h.transport, err = hc.NewIPTransport(h.config, h.bridge.Accessory, accessories...)
 	if err != nil {
 		log.Err(err)
 	}
 
 	hc.OnTermination(func() {
 		log.Event("Module 'homekit' is terminating.")
-		<-t.Stop()
+		<-h.transport.Stop()
 	})
 
-	t.Start()
+	h.transport.Start()
 
+}
+
+func (h *Homekit) Run() error {
+
+	// Wait for modules to load
+	time.Sleep(time.Second * 5)
+	// Begin hosting in a new thead
+	go h.Host()
+
+	return nil
+}
+
+func (h *Homekit) Dispose() error {
+	<-h.transport.Stop()
 	return nil
 }
 

--- a/modules/homekit/homekit.go
+++ b/modules/homekit/homekit.go
@@ -112,11 +112,6 @@ func (h *Homekit) Host() {
 		log.Err(err)
 	}
 
-	hc.OnTermination(func() {
-		log.Event("Module 'homekit' is terminating.")
-		<-h.transport.Stop()
-	})
-
 	h.transport.Start()
 
 }

--- a/modules/weather/weather.go
+++ b/modules/weather/weather.go
@@ -181,10 +181,6 @@ func (v *Weather) Run() error {
 		return err
 	}
 
-	err = v.fetchWeather()
-	if err != nil {
-
-	}
 	buffer, err := v.forecastBuffer()
 	if err != nil {
 		return err
@@ -201,11 +197,6 @@ func (v *Weather) Run() error {
 	v.eId = e.Id
 
 	err = v.Attributes.Register(forecast)
-	if err != nil {
-		return err
-	}
-
-	err = v.pull()
 	if err != nil {
 		return err
 	}

--- a/modules/weather/weather.go
+++ b/modules/weather/weather.go
@@ -30,7 +30,7 @@ type WeatherAPI struct {
 		Temperature   float64 `json:"temperature"`
 		Winddirection float64 `json:"winddirection"`
 		Weathercode   float64 `json:"weathercode"`
-		Time          float64 `json:"time"`
+		Time          string  `json:"time"`
 		Windspeed     float64 `json:"windspeed"`
 	} `json:"current_weather"`
 	Hourly      Hourly      `json:"hourly"`

--- a/modules/worldspace/worldspace.go
+++ b/modules/worldspace/worldspace.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2022 Braden Nicholson
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-chi/chi"
+	"net/http"
+	"udap/internal/plugin"
+)
+
+var Module Worldspace
+
+type Worldspace struct {
+	plugin.Module
+	server http.Server
+}
+
+func init() {
+	config := plugin.Config{
+		Name:        "worldspace",
+		Type:        "module",
+		Description: "worldspace integration",
+		Version:     "0.0.1",
+		Author:      "Braden Nicholson",
+	}
+	Module.Config = config
+}
+
+func (w *Worldspace) Setup() (plugin.Config, error) {
+	err := w.UpdateInterval(1000)
+	if err != nil {
+		return plugin.Config{}, err
+	}
+
+	fmt.Println("Setting up Worldspace")
+	return w.Config, nil
+}
+
+func (w *Worldspace) Update() error {
+	if w.Ready() {
+		// fmt.Println("Updating worldspace")
+	}
+	return nil
+}
+
+func (w *Worldspace) handleMotion(writer http.ResponseWriter, request *http.Request) {
+	/*zone := chi.URLParam(request, "zone")*/
+
+}
+
+func (w *Worldspace) Run() error {
+	w.server = http.Server{}
+	w.server.Addr = ":5055"
+
+	router := chi.NewRouter()
+	router.Post("/motion/{zone}", w.handleMotion)
+
+	fmt.Println("Running worldspace")
+
+	go func() {
+		err := w.server.ListenAndServe()
+		if err != nil {
+			return
+		}
+	}()
+	return nil
+}
+
+func (w *Worldspace) Dispose() error {
+	ctx := context.Background()
+	err := w.server.Shutdown(ctx)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Disposing worldspace")
+	return nil
+}

--- a/modules/worldspace/worldspace.go
+++ b/modules/worldspace/worldspace.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"github.com/go-chi/chi"
 	"net/http"
 	"udap/internal/plugin"
@@ -29,17 +28,17 @@ func init() {
 }
 
 func (w *Worldspace) Setup() (plugin.Config, error) {
-	err := w.UpdateInterval(1000)
+	err := w.UpdateInterval(2000)
 	if err != nil {
 		return plugin.Config{}, err
 	}
 
-	fmt.Println("Setting up Worldspace")
 	return w.Config, nil
 }
 
 func (w *Worldspace) Update() error {
 	if w.Ready() {
+
 		// fmt.Println("Updating worldspace")
 	}
 	return nil
@@ -57,8 +56,6 @@ func (w *Worldspace) Run() error {
 	router := chi.NewRouter()
 	router.Post("/motion/{zone}", w.handleMotion)
 
-	fmt.Println("Running worldspace")
-
 	go func() {
 		err := w.server.ListenAndServe()
 		if err != nil {
@@ -74,6 +71,5 @@ func (w *Worldspace) Dispose() error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("Disposing worldspace")
 	return nil
 }


### PR DESCRIPTION
### Networking
- Added device page to nexus; it shows all connected devices, their latency, and provides options to rename and change settings.
- Added arp scanning to the vyos module, which drives the nexus devices page
- Added icmp ping packets to the vyos module, replacing the exec based ping method used previously (this removes about 50-100ms of exec time on each address)
- Improved whole network discovery and latency collection rate (15s down to 400ms)
- Added device monitoring which shows CPU usage, Memory allocation, disk usage, and network throughput on select devices

### Endpoints
- Improved the endpoint communication protocol
- Forced the endpoint runtime to defer clean up to the end of the connection lifespan, which guarantees a clean disconnect
- Improved endpoint acquisition and re-acquisition

### Notifications
- Added notification struct to the udap runtime domain
- Created repository, service, and operator for notifications

### Nexus Preferences
- Unified the nexus persistent preferences
- Removed the preference class in favor of a simple provide/inject exported interface

### Module Runtime
- Added module disposal to shutdown sequence
- Created a safe-mode for modules
- Added panic recovery to the update loop in order to prevent the primary system from also panicking
- Created a sequence to safely dispose of a panicked module's runtime